### PR TITLE
Add test coverage for acceptedScope

### DIFF
--- a/adapters/oak_deps.ts
+++ b/adapters/oak_deps.ts
@@ -3,8 +3,8 @@ export {
   Cookies,
   Request,
   Response,
-} from "https://deno.land/x/oak@v9.0.0/mod.ts";
+} from "https://deno.land/x/oak@v9.0.1/mod.ts";
 export type {
   BodyForm,
   Middleware,
-} from "https://deno.land/x/oak@v9.0.0/mod.ts";
+} from "https://deno.land/x/oak@v9.0.1/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
-export { createHash } from "https://deno.land/std@0.106.0/hash/mod.ts";
+export { createHash } from "https://deno.land/std@0.107.0/hash/mod.ts";
 export {
   decode as decodeBase64url,
   encode as encodeBase64url,
-} from "https://deno.land/std@0.106.0/encoding/base64url.ts";
-export { resolve } from "https://deno.land/std@0.106.0/path/mod.ts";
+} from "https://deno.land/std@0.107.0/encoding/base64url.ts";
+export { resolve } from "https://deno.land/std@0.107.0/path/mod.ts";

--- a/examples/oak-localstorage/deps.ts
+++ b/examples/oak-localstorage/deps.ts
@@ -4,13 +4,13 @@ export {
   Cookies,
   Response,
   Router,
-} from "https://deno.land/x/oak@v9.0.0/mod.ts";
-export type { BodyForm } from "https://deno.land/x/oak@v9.0.0/mod.ts";
+} from "https://deno.land/x/oak@v9.0.1/mod.ts";
+export type { BodyForm } from "https://deno.land/x/oak@v9.0.1/mod.ts";
 
-export { createHash } from "https://deno.land/std@0.106.0/hash/mod.ts";
+export { createHash } from "https://deno.land/std@0.107.0/hash/mod.ts";
 export {
   encode as encodeBase64,
-} from "https://deno.land/std@0.106.0/encoding/base64.ts";
+} from "https://deno.land/std@0.107.0/encoding/base64.ts";
 
 export {
   AbstractAccessTokenService,

--- a/grants/grant.ts
+++ b/grants/grant.ts
@@ -9,7 +9,7 @@ import {
   ScopeInterface,
 } from "../models/scope.ts";
 import type { User } from "../models/user.ts";
-import { InvalidClient, InvalidScope, ServerError } from "../errors.ts";
+import { InvalidClient, InvalidScope } from "../errors.ts";
 import { BasicAuth, parseBasicAuth } from "../basic_auth.ts";
 
 export interface GrantServices<Scope extends ScopeInterface> {
@@ -75,7 +75,6 @@ export abstract class AbstractGrant<Scope extends ScopeInterface = DefaultScope>
     scope?: Scope,
   ): Promise<Scope | undefined> {
     const { tokenService } = this.services;
-    if (!tokenService) throw new ServerError("token service required");
     const acceptedScope = await tokenService.acceptedScope(client, user, scope);
     if (acceptedScope === false) {
       throw new InvalidScope(scope ? "invalid scope" : "scope required");

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -7,9 +7,9 @@ export {
   assertStrictEquals,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.106.0/testing/asserts.ts";
-export { delay } from "https://deno.land/std@0.106.0/async/delay.ts";
-export { v4 } from "https://deno.land/std@0.106.0/uuid/mod.ts";
+} from "https://deno.land/std@0.107.0/testing/asserts.ts";
+export { delay } from "https://deno.land/std@0.107.0/async/delay.ts";
+export { v4 } from "https://deno.land/std@0.107.0/uuid/mod.ts";
 
 export {
   assertSpyCall,
@@ -20,11 +20,11 @@ export {
   resolves,
   spy,
   stub,
-} from "https://deno.land/x/mock@v0.10.0/mod.ts";
+} from "https://deno.land/x/mock@0.10.1/mod.ts";
 export type {
   Spy,
   SpyCall,
   Stub,
-} from "https://deno.land/x/mock@v0.10.0/mod.ts";
+} from "https://deno.land/x/mock@0.10.1/mod.ts";
 
-export { test, TestSuite } from "https://deno.land/x/test_suite@v0.7.1/mod.ts";
+export { test, TestSuite } from "https://deno.land/x/test_suite@0.9.0/mod.ts";


### PR DESCRIPTION
Resolves https://github.com/udibo/oauth2_server/issues/1

I removed the check for whether or not tokenService is available because it is required for all grants. I added test coverage in all the places specified in the issue linked above. I forgot to bump dependency versions in my last release, so I included that with this for the next release.