### PR TITLE
Use HttpError as base class for OAuth2Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OAuth2 Server
 
-[![version](https://img.shields.io/badge/release-0.6.1-success)](https://deno.land/x/oauth2_server@0.6.1)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/oauth2_server@0.6.1/authorization_server.ts)
+[![version](https://img.shields.io/badge/release-0.7.0-success)](https://deno.land/x/oauth2_server@0.7.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/oauth2_server@0.7.0/authorization_server.ts)
 [![CI](https://github.com/udibo/oauth2_server/workflows/CI/badge.svg)](https://github.com/udibo/oauth2_server/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/oauth2_server/branch/main/graph/badge.svg?token=8Q7TSUFWUY)](https://codecov.io/gh/udibo/oauth2_server)
 [![license](https://img.shields.io/github/license/udibo/oauth2_server)](https://github.com/udibo/oauth2_server/blob/master/LICENSE)
@@ -44,9 +44,9 @@ also acting as an authorization server.
 
 ```ts
 // Import from Deno's third party module registry
-import { ResourceServer } from "https://deno.land/x/oauth2_server@0.6.1/resource_server.ts";
+import { ResourceServer } from "https://deno.land/x/oauth2_server@0.7.0/resource_server.ts";
 // Import from GitHub
-import { ResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.6.1/resource_server.ts";
+import { ResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.7.0/resource_server.ts";
 ```
 
 The AuthorizationServer is an extension of the ResourceServer, adding methods
@@ -54,9 +54,9 @@ used by the authorize and token endpoints.
 
 ```ts
 // Import from Deno's third party module registry
-import { AuthorizationServer } from "https://deno.land/x/oauth2_server@0.6.1/authorization_server.ts";
+import { AuthorizationServer } from "https://deno.land/x/oauth2_server@0.7.0/authorization_server.ts";
 // Import from GitHub
-import { AuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.6.1/authorization_server.ts";
+import { AuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.7.0/authorization_server.ts";
 ```
 
 ## Usage
@@ -66,7 +66,7 @@ An example of how to use this module can be found
 but it should give you an idea of how to use this module.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.6.1/authorization_server.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.7.0/authorization_server.ts)
 for more information.
 
 ### Grants

--- a/adapters/oak/README.md
+++ b/adapters/oak/README.md
@@ -20,9 +20,9 @@ also acting as an authorization server.
 
 ```ts
 // Import from Deno's third party module registry
-import { OakResourceServer } from "https://deno.land/x/oauth2_server@0.6.1/adapters/oak/resource_server.ts";
+import { OakResourceServer } from "https://deno.land/x/oauth2_server@0.7.0/adapters/oak/resource_server.ts";
 // Import from GitHub
-import { OakResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.6.1/adapters/oak/resource_server.ts";
+import { OakResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.7.0/adapters/oak/resource_server.ts";
 ```
 
 The AuthorizationServer is an extension of the ResourceServer, adding methods
@@ -30,9 +30,9 @@ used by the authorize and token endpoints.
 
 ```ts
 // Import from Deno's third party module registry
-import { OakAuthorizationServer } from "https://deno.land/x/oauth2_server@0.6.1/adapters/oak/authorization_server.ts";
+import { OakAuthorizationServer } from "https://deno.land/x/oauth2_server@0.7.0/adapters/oak/authorization_server.ts";
 // Import from GitHub
-import { OakAuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.6.1/adapters/oak/authorization_server.ts";
+import { OakAuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.7.0/adapters/oak/authorization_server.ts";
 ```
 
 ## Usage
@@ -42,5 +42,5 @@ An example of how to use this adapter module can be found
 but it should give you an idea of how to use this module.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.6.1/adapters/oak/authorization_server.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.7.0/adapters/oak/authorization_server.ts)
 for more information.

--- a/basic_auth.ts
+++ b/basic_auth.ts
@@ -1,4 +1,4 @@
-import { InvalidClient } from "./errors.ts";
+import { InvalidClientError } from "./errors.ts";
 
 const CREDENTIALS = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([\w-.~+/]+=*) *$/;
 const NAME_PASS = /^([^:]+):(.*)$/;
@@ -10,23 +10,23 @@ export interface BasicAuth {
 
 export function parseBasicAuth(authorization: string | null): BasicAuth {
   if (!authorization) {
-    throw new InvalidClient("authorization header required");
+    throw new InvalidClientError("authorization header required");
   }
   let match = CREDENTIALS.exec(authorization);
   if (!match) {
-    throw new InvalidClient("unsupported authorization header");
+    throw new InvalidClientError("unsupported authorization header");
   }
   let value: string;
   try {
     value = atob(match[1]);
   } catch {
-    throw new InvalidClient(
+    throw new InvalidClientError(
       "authorization header is not correctly encoded",
     );
   }
   match = NAME_PASS.exec(value);
   if (!match) {
-    throw new InvalidClient("authorization header is malformed");
+    throw new InvalidClientError("authorization header is malformed");
   }
   return {
     name: match[1],

--- a/basic_auth_test.ts
+++ b/basic_auth_test.ts
@@ -1,6 +1,6 @@
 import { BasicAuth, parseBasicAuth } from "./basic_auth.ts";
 import { assertEquals, assertThrows, test, TestSuite } from "./test_deps.ts";
-import { InvalidClient } from "./errors.ts";
+import { InvalidClientError } from "./errors.ts";
 
 const parseBasicAuthTests: TestSuite<void> = new TestSuite({
   name: "parseBasicAuth",
@@ -9,12 +9,12 @@ const parseBasicAuthTests: TestSuite<void> = new TestSuite({
 test(parseBasicAuthTests, "authorization header required", () => {
   assertThrows(
     () => parseBasicAuth(null),
-    InvalidClient,
+    InvalidClientError,
     "authorization header required",
   );
   assertThrows(
     () => parseBasicAuth(""),
-    InvalidClient,
+    InvalidClientError,
     "authorization header required",
   );
 });
@@ -22,17 +22,17 @@ test(parseBasicAuthTests, "authorization header required", () => {
 test(parseBasicAuthTests, "unsupported authorization header", () => {
   assertThrows(
     () => parseBasicAuth("x"),
-    InvalidClient,
+    InvalidClientError,
     "unsupported authorization header",
   );
   assertThrows(
     () => parseBasicAuth("basic"),
-    InvalidClient,
+    InvalidClientError,
     "unsupported authorization header",
   );
   assertThrows(
     () => parseBasicAuth("Bearer mF_9.B5f-4.1JqM"),
-    InvalidClient,
+    InvalidClientError,
     "unsupported authorization header",
   );
 });
@@ -43,12 +43,12 @@ test(
   () => {
     assertThrows(
       () => parseBasicAuth("basic x"),
-      InvalidClient,
+      InvalidClientError,
       "authorization header is not correctly encoded",
     );
     assertThrows(
       () => parseBasicAuth(`basic ${btoa("kyle")}=`),
-      InvalidClient,
+      InvalidClientError,
       "authorization header is not correctly encoded",
     );
   },
@@ -57,17 +57,17 @@ test(
 test(parseBasicAuthTests, "authorization header is malformed", () => {
   assertThrows(
     () => parseBasicAuth(`basic ${btoa("kyle")}`),
-    InvalidClient,
+    InvalidClientError,
     "authorization header is malformed",
   );
   assertThrows(
     () => parseBasicAuth(`basic ${btoa(":")}`),
-    InvalidClient,
+    InvalidClientError,
     "authorization header is malformed",
   );
   assertThrows(
     () => parseBasicAuth(`basic ${btoa(":hunter2")}`),
-    InvalidClient,
+    InvalidClientError,
     "authorization header is malformed",
   );
 });

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,12 @@
-export { createHash } from "https://deno.land/std@0.110.0/hash/mod.ts";
+export { createHash } from "https://deno.land/std@0.111.0/hash/mod.ts";
 export {
   decode as decodeBase64url,
   encode as encodeBase64url,
-} from "https://deno.land/std@0.110.0/encoding/base64url.ts";
-export { resolve } from "https://deno.land/std@0.110.0/path/mod.ts";
+} from "https://deno.land/std@0.111.0/encoding/base64url.ts";
+export { resolve } from "https://deno.land/std@0.111.0/path/mod.ts";
+export {
+  HttpError,
+  isHttpError,
+  optionsFromArgs,
+} from "https://deno.land/x/http_error@0.1.2/mod.ts";
+export type { HttpErrorInit } from "https://deno.land/x/http_error@0.1.2/mod.ts";

--- a/errors_test.ts
+++ b/errors_test.ts
@@ -1,16 +1,16 @@
-import { assertObjectMatch, test } from "./test_deps.ts";
+import { assertEquals, assertObjectMatch, test } from "./test_deps.ts";
 import {
-  AccessDenied,
-  InvalidClient,
-  InvalidGrant,
-  InvalidRequest,
-  InvalidScope,
+  AccessDeniedError,
+  InvalidClientError,
+  InvalidGrantError,
+  InvalidRequestError,
+  InvalidScopeError,
   OAuth2Error,
   ServerError,
-  TemporarilyUnavailable,
-  UnauthorizedClient,
-  UnsupportedGrantType,
-  UnsupportedResponseType,
+  TemporarilyUnavailableError,
+  UnauthorizedClientError,
+  UnsupportedGrantTypeError,
+  UnsupportedResponseTypeError,
 } from "./errors.ts";
 
 test("OAuth2Error", () => {
@@ -18,14 +18,14 @@ test("OAuth2Error", () => {
   assertObjectMatch(new CustomError(), {
     name: "OAuth2Error",
     status: 500,
-    code: undefined,
+    code: "server_error",
     uri: undefined,
   });
   assertObjectMatch(new CustomError("failed"), {
     name: "OAuth2Error",
     message: "failed",
     status: 500,
-    code: undefined,
+    code: "server_error",
     uri: undefined,
   });
   assertObjectMatch(
@@ -46,260 +46,212 @@ test("OAuth2Error", () => {
   );
 });
 
-test("InvalidRequest", () => {
-  assertObjectMatch(new InvalidRequest(), {
-    name: "InvalidRequest",
+test("InvalidRequestError", () => {
+  assertObjectMatch(new InvalidRequestError(), {
+    name: "InvalidRequestError",
     status: 400,
     code: "invalid_request",
     uri: undefined,
   });
-  assertObjectMatch(new InvalidRequest("failed"), {
-    name: "InvalidRequest",
+  assertObjectMatch(new InvalidRequestError("failed"), {
+    name: "InvalidRequestError",
     message: "failed",
     status: 400,
     code: "invalid_request",
     uri: undefined,
   });
-  assertObjectMatch(
-    new InvalidRequest({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new InvalidRequestError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "InvalidRequestError",
+    message: "failed",
+    status: 400,
+    code: "invalid_request",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("InvalidClient", () => {
-  assertObjectMatch(new InvalidClient(), {
-    name: "InvalidClient",
+test("InvalidClientError", () => {
+  assertObjectMatch(new InvalidClientError(), {
+    name: "InvalidClientError",
     status: 401,
     code: "invalid_client",
     uri: undefined,
   });
-  assertObjectMatch(new InvalidClient("failed"), {
-    name: "InvalidClient",
+  assertObjectMatch(new InvalidClientError("failed"), {
+    name: "InvalidClientError",
     message: "failed",
     status: 401,
     code: "invalid_client",
     uri: undefined,
   });
-  assertObjectMatch(
-    new InvalidClient({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new InvalidClientError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "InvalidClientError",
+    message: "failed",
+    status: 401,
+    code: "invalid_client",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("InvalidGrant", () => {
-  assertObjectMatch(new InvalidGrant(), {
-    name: "InvalidGrant",
+test("InvalidGrantError", () => {
+  assertObjectMatch(new InvalidGrantError(), {
+    name: "InvalidGrantError",
     status: 400,
     code: "invalid_grant",
     uri: undefined,
   });
-  assertObjectMatch(new InvalidGrant("failed"), {
-    name: "InvalidGrant",
+  assertObjectMatch(new InvalidGrantError("failed"), {
+    name: "InvalidGrantError",
     message: "failed",
     status: 400,
     code: "invalid_grant",
     uri: undefined,
   });
-  assertObjectMatch(
-    new InvalidGrant({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new InvalidGrantError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "InvalidGrantError",
+    message: "failed",
+    status: 400,
+    code: "invalid_grant",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("UnauthorizedClient", () => {
-  assertObjectMatch(new UnauthorizedClient(), {
-    name: "UnauthorizedClient",
+test("UnauthorizedClientError", () => {
+  assertObjectMatch(new UnauthorizedClientError(), {
+    name: "UnauthorizedClientError",
     status: 401,
     code: "unauthorized_client",
     uri: undefined,
   });
-  assertObjectMatch(new UnauthorizedClient("failed"), {
-    name: "UnauthorizedClient",
+  assertObjectMatch(new UnauthorizedClientError("failed"), {
+    name: "UnauthorizedClientError",
     message: "failed",
     status: 401,
     code: "unauthorized_client",
     uri: undefined,
   });
-  assertObjectMatch(
-    new UnauthorizedClient({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new UnauthorizedClientError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "UnauthorizedClientError",
+    message: "failed",
+    status: 401,
+    code: "unauthorized_client",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("UnsupportedGrantType", () => {
-  assertObjectMatch(new UnsupportedGrantType(), {
-    name: "UnsupportedGrantType",
+test("UnsupportedGrantTypeError", () => {
+  assertObjectMatch(new UnsupportedGrantTypeError(), {
+    name: "UnsupportedGrantTypeError",
     status: 400,
     code: "unsupported_grant_type",
     uri: undefined,
   });
-  assertObjectMatch(new UnsupportedGrantType("failed"), {
-    name: "UnsupportedGrantType",
+  assertObjectMatch(new UnsupportedGrantTypeError("failed"), {
+    name: "UnsupportedGrantTypeError",
     message: "failed",
     status: 400,
     code: "unsupported_grant_type",
     uri: undefined,
   });
-  assertObjectMatch(
-    new UnsupportedGrantType({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new UnsupportedGrantTypeError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "UnsupportedGrantTypeError",
+    message: "failed",
+    status: 400,
+    code: "unsupported_grant_type",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("AccessDenied", () => {
-  assertObjectMatch(new AccessDenied(), {
-    name: "AccessDenied",
+test("AccessDeniedError", () => {
+  assertObjectMatch(new AccessDeniedError(), {
+    name: "AccessDeniedError",
     status: 401,
     code: "access_denied",
     uri: undefined,
   });
-  assertObjectMatch(new AccessDenied("failed"), {
-    name: "AccessDenied",
+  assertObjectMatch(new AccessDeniedError("failed"), {
+    name: "AccessDeniedError",
     message: "failed",
     status: 401,
     code: "access_denied",
     uri: undefined,
   });
-  assertObjectMatch(
-    new AccessDenied({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new AccessDeniedError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "AccessDeniedError",
+    message: "failed",
+    status: 401,
+    code: "access_denied",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("UnsupportedResponseType", () => {
-  assertObjectMatch(new UnsupportedResponseType(), {
-    name: "UnsupportedResponseType",
+test("UnsupportedResponseTypeError", () => {
+  assertObjectMatch(new UnsupportedResponseTypeError(), {
+    name: "UnsupportedResponseTypeError",
     status: 400,
     code: "unsupported_response_type",
     uri: undefined,
   });
-  assertObjectMatch(new UnsupportedResponseType("failed"), {
-    name: "UnsupportedResponseType",
+  assertObjectMatch(new UnsupportedResponseTypeError("failed"), {
+    name: "UnsupportedResponseTypeError",
     message: "failed",
     status: 400,
     code: "unsupported_response_type",
     uri: undefined,
   });
-  assertObjectMatch(
-    new UnsupportedResponseType({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new UnsupportedResponseTypeError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "UnsupportedResponseTypeError",
+    message: "failed",
+    status: 400,
+    code: "unsupported_response_type",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("InvalidScope", () => {
-  assertObjectMatch(new InvalidScope(), {
-    name: "InvalidScope",
+test("InvalidScopeError", () => {
+  assertObjectMatch(new InvalidScopeError(), {
+    name: "InvalidScopeError",
     status: 400,
     code: "invalid_scope",
     uri: undefined,
   });
-  assertObjectMatch(new InvalidScope("failed"), {
-    name: "InvalidScope",
+  assertObjectMatch(new InvalidScopeError("failed"), {
+    name: "InvalidScopeError",
     message: "failed",
     status: 400,
     code: "invalid_scope",
     uri: undefined,
   });
-  assertObjectMatch(
-    new InvalidScope({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new InvalidScopeError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "InvalidScopeError",
+    message: "failed",
+    status: 400,
+    code: "invalid_scope",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
 test("ServerError", () => {
@@ -316,52 +268,40 @@ test("ServerError", () => {
     code: "server_error",
     uri: undefined,
   });
-  assertObjectMatch(
-    new ServerError({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new ServerError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "ServerError",
+    message: "failed",
+    status: 500,
+    code: "server_error",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });
 
-test("TemporarilyUnavailable", () => {
-  assertObjectMatch(new TemporarilyUnavailable(), {
-    name: "TemporarilyUnavailable",
+test("TemporarilyUnavailableError", () => {
+  assertObjectMatch(new TemporarilyUnavailableError(), {
+    name: "TemporarilyUnavailableError",
     status: 503,
     code: "temporarily_unavailable",
     uri: undefined,
   });
-  assertObjectMatch(new TemporarilyUnavailable("failed"), {
-    name: "TemporarilyUnavailable",
+  assertObjectMatch(new TemporarilyUnavailableError("failed"), {
+    name: "TemporarilyUnavailableError",
     message: "failed",
     status: 503,
     code: "temporarily_unavailable",
     uri: undefined,
   });
-  assertObjectMatch(
-    new TemporarilyUnavailable({
-      name: "CustomError",
-      message: "failed",
-      code: "custom_error",
-      status: 418,
-      uri: "https://example.com",
-    }),
-    {
-      name: "CustomError",
-      message: "failed",
-      status: 418,
-      code: "custom_error",
-      uri: "https://example.com",
-    },
-  );
+  const cause = new Error("something went wrong");
+  const error = new TemporarilyUnavailableError("failed", { cause });
+  assertObjectMatch(error, {
+    name: "TemporarilyUnavailableError",
+    message: "failed",
+    status: 503,
+    code: "temporarily_unavailable",
+    uri: undefined,
+  });
+  assertEquals(error.cause, cause);
 });

--- a/examples/oak-localstorage/deps.ts
+++ b/examples/oak-localstorage/deps.ts
@@ -7,10 +7,10 @@ export {
 } from "https://deno.land/x/oak@v9.0.1/mod.ts";
 export type { BodyForm } from "https://deno.land/x/oak@v9.0.1/mod.ts";
 
-export { createHash } from "https://deno.land/std@0.110.0/hash/mod.ts";
+export { createHash } from "https://deno.land/std@0.111.0/hash/mod.ts";
 export {
   encode as encodeBase64,
-} from "https://deno.land/std@0.110.0/encoding/base64.ts";
+} from "https://deno.land/std@0.111.0/encoding/base64.ts";
 
 export {
   AbstractAccessTokenService,

--- a/examples/oak-localstorage/oauth2.ts
+++ b/examples/oak-localstorage/oauth2.ts
@@ -139,8 +139,10 @@ const consentPage = (
     </head>
     <body>
       <form method="post">
-        <input type="text" readonly name="authorized_scope" value="${authorizeParameters
-  .scope ?? ""}"/>
+        <input type="text" readonly name="authorized_scope" value="${
+  authorizeParameters
+    .scope ?? ""
+}"/>
         <input type="submit" value="Consent"/>
       </form>
     </body>

--- a/grants/authorization_code_test.ts
+++ b/grants/authorization_code_test.ts
@@ -23,9 +23,9 @@ import {
   TestSuite,
 } from "../test_deps.ts";
 import {
-  InvalidClient,
-  InvalidGrant,
-  InvalidRequest,
+  InvalidClientError,
+  InvalidGrantError,
+  InvalidRequestError,
   ServerError,
 } from "../errors.ts";
 import { fakeTokenRequest } from "../test_context.ts";
@@ -136,7 +136,7 @@ test(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
     request.headers.delete("authorization");
     await assertRejects(
       () => authorizationCodeGrant.getAuthenticatedClient(request),
-      InvalidClient,
+      InvalidClientError,
       "authorization header required",
     );
 
@@ -174,7 +174,7 @@ test(
       request.headers.delete("authorization");
       await assertRejects(
         () => authorizationCodeGrant.getAuthenticatedClient(request),
-        InvalidClient,
+        InvalidClientError,
         "client authentication failed",
       );
 
@@ -218,7 +218,7 @@ test(
       request.headers.set("authorization", `basic ${btoa("1:2")}`);
       await assertRejects(
         () => authorizationCodeGrant.getAuthenticatedClient(request),
-        InvalidClient,
+        InvalidClientError,
         "client authentication failed",
       );
 
@@ -268,7 +268,7 @@ test(
       request.headers.delete("authorization");
       await assertRejects(
         () => authorizationCodeGrant.getAuthenticatedClient(request),
-        InvalidClient,
+        InvalidClientError,
         "client authentication failed",
       );
 
@@ -601,7 +601,7 @@ test(tokenTests, "request body required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "request body required",
   );
 });
@@ -615,14 +615,14 @@ test(tokenTests, "code parameter required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "code parameter required",
   );
 
   request = fakeTokenRequest("username=");
   await assertRejects(
     () => authorizationCodeGrant.token(request, client),
-    InvalidRequest,
+    InvalidRequestError,
     "code parameter required",
   );
 });
@@ -642,7 +642,7 @@ test(tokenTests, "code already used", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "code already used",
     );
 
@@ -671,7 +671,7 @@ test(tokenTests, "invalid code", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "invalid code",
     );
 
@@ -704,7 +704,7 @@ test(tokenTests, "expired code", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "invalid code",
     );
 
@@ -737,7 +737,7 @@ test(tokenTests, "code was issued to another client", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidClient,
+      InvalidClientError,
       "code was issued to another client",
     );
 
@@ -765,7 +765,7 @@ test(tokenTests, "redirect_uri parameter required", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "redirect_uri parameter required",
     );
 
@@ -778,7 +778,7 @@ test(tokenTests, "redirect_uri parameter required", async () => {
     request = fakeTokenRequest("code=1&redirect_uri=");
     await assertRejects(
       () => authorizationCodeGrant.token(request, client),
-      InvalidGrant,
+      InvalidGrantError,
       "redirect_uri parameter required",
     );
 
@@ -810,7 +810,7 @@ test(tokenTests, "incorrect redirect_uri", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "incorrect redirect_uri",
     );
 
@@ -827,7 +827,7 @@ test(tokenTests, "incorrect redirect_uri", async () => {
     );
     await assertRejects(
       () => authorizationCodeGrant.token(request, client),
-      InvalidGrant,
+      InvalidGrantError,
       "incorrect redirect_uri",
     );
 
@@ -864,7 +864,7 @@ test(tokenTests, "did not expect redirect_uri parameter", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "did not expect redirect_uri parameter",
     );
 
@@ -914,7 +914,7 @@ test(
       assertStrictEquals(Promise.resolve(result), result);
       await assertRejects(
         () => result,
-        InvalidClient,
+        InvalidClientError,
         "client authentication failed",
       );
 
@@ -962,7 +962,7 @@ test(
       assertStrictEquals(Promise.resolve(result), result);
       await assertRejects(
         () => result,
-        InvalidClient,
+        InvalidClientError,
         "client authentication failed",
       );
 

--- a/grants/client_credentials.ts
+++ b/grants/client_credentials.ts
@@ -1,5 +1,5 @@
 import { AbstractGrant, GrantInterface, GrantServices } from "./grant.ts";
-import { InvalidGrant, InvalidRequest } from "../errors.ts";
+import { InvalidGrantError, InvalidRequestError } from "../errors.ts";
 import {
   Scope as DefaultScope,
   ScopeConstructor,
@@ -58,7 +58,9 @@ export class ClientCredentialsGrant<
     request: OAuth2Request<Client, User, Scope>,
     client: Client,
   ): Promise<Token<Client, User, Scope>> {
-    if (!request.hasBody) throw new InvalidRequest("request body required");
+    if (!request.hasBody) {
+      throw new InvalidRequestError("request body required");
+    }
 
     const body: URLSearchParams = await request.body!;
     const scopeText: string | null = body.get("scope");
@@ -66,7 +68,7 @@ export class ClientCredentialsGrant<
 
     const { tokenService, clientService } = this.services;
     const user: User | void = await clientService.getUser(client);
-    if (!user) throw new InvalidGrant("no user for client");
+    if (!user) throw new InvalidGrantError("no user for client");
 
     scope = await this.acceptedScope(client, user, scope);
 

--- a/grants/client_credentials_test.ts
+++ b/grants/client_credentials_test.ts
@@ -19,9 +19,9 @@ import {
   TestSuite,
 } from "../test_deps.ts";
 import {
-  InvalidGrant,
-  InvalidRequest,
-  InvalidScope,
+  InvalidGrantError,
+  InvalidRequestError,
+  InvalidScopeError,
   ServerError,
 } from "../errors.ts";
 import { fakeTokenRequest } from "../test_context.ts";
@@ -93,7 +93,7 @@ test(tokenTests, "request body required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "request body required",
   );
 });
@@ -109,14 +109,14 @@ test(tokenTests, "invalid scope", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidScope,
+      InvalidScopeError,
       "invalid scope",
     );
 
     request = fakeTokenRequest("scope= ");
     await assertRejects(
       () => clientCredentialsGrant.token(request, client),
-      InvalidScope,
+      InvalidScopeError,
       "invalid scope",
     );
   } finally {
@@ -139,7 +139,7 @@ test(tokenTests, "no user for client", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "no user for client",
     );
     assertStrictEquals(getUser.calls.length, 1);
@@ -162,7 +162,7 @@ test(tokenTests, "scope not accepted", async () => {
   const acceptedScope = stub(
     clientCredentialsGrant,
     "acceptedScope",
-    () => Promise.reject(new InvalidScope("invalid scope")),
+    () => Promise.reject(new InvalidScopeError("invalid scope")),
   );
   try {
     const request = fakeTokenRequest("scope=read write");
@@ -173,7 +173,7 @@ test(tokenTests, "scope not accepted", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidScope,
+      InvalidScopeError,
       "invalid scope",
     );
 

--- a/grants/grant.ts
+++ b/grants/grant.ts
@@ -8,7 +8,7 @@ import {
   ScopeConstructor,
   ScopeInterface,
 } from "../models/scope.ts";
-import { InvalidClient, InvalidScope } from "../errors.ts";
+import { InvalidClientError, InvalidScopeError } from "../errors.ts";
 import { BasicAuth, parseBasicAuth } from "../basic_auth.ts";
 
 export interface GrantServices<
@@ -96,7 +96,7 @@ export abstract class AbstractGrant<
     const { tokenService } = this.services;
     const acceptedScope = await tokenService.acceptedScope(client, user, scope);
     if (acceptedScope === false) {
-      throw new InvalidScope(scope ? "invalid scope" : "scope required");
+      throw new InvalidScopeError(scope ? "invalid scope" : "scope required");
     }
     return acceptedScope;
   }
@@ -136,7 +136,7 @@ export abstract class AbstractGrant<
     const client: Client | void = clientSecret
       ? await clientService.getAuthenticated(clientId, clientSecret)
       : await clientService.getAuthenticated(clientId);
-    if (!client) throw new InvalidClient("client authentication failed");
+    if (!client) throw new InvalidClientError("client authentication failed");
     return client;
   }
 

--- a/grants/grant_test.ts
+++ b/grants/grant_test.ts
@@ -23,7 +23,7 @@ import {
   TestSuite,
 } from "../test_deps.ts";
 import { fakeTokenRequest } from "../test_context.ts";
-import { InvalidClient, InvalidScope } from "../errors.ts";
+import { InvalidClientError, InvalidScopeError } from "../errors.ts";
 import {
   ClientService,
   RefreshTokenService,
@@ -155,7 +155,7 @@ test(acceptedScopeTests, "invalid scope", async () => {
   try {
     await assertRejects(
       () => grant.acceptedScope(client, user, scope),
-      InvalidScope,
+      InvalidScopeError,
       "invalid scope",
     );
 
@@ -182,7 +182,7 @@ test(acceptedScopeTests, "scope required", async () => {
   try {
     await assertRejects(
       () => grant.acceptedScope(client, user),
-      InvalidScope,
+      InvalidScopeError,
       "scope required",
     );
 
@@ -206,7 +206,7 @@ test(
     request.headers.delete("authorization");
     await assertRejects(
       () => grant.getClientCredentials(request),
-      InvalidClient,
+      InvalidClientError,
       "authorization header required",
     );
   },
@@ -292,7 +292,7 @@ test(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
     request.headers.delete("authorization");
     await assertRejects(
       () => grant.getAuthenticatedClient(request),
-      InvalidClient,
+      InvalidClientError,
       "authorization header required",
     );
 
@@ -327,7 +327,7 @@ test(
       request.headers.set("authorization", `basic ${btoa("1:")}`);
       await assertRejects(
         () => grant.getAuthenticatedClient(request),
-        InvalidClient,
+        InvalidClientError,
         "client authentication failed",
       );
 
@@ -366,7 +366,7 @@ test(
       request.headers.set("authorization", `basic ${btoa("1:2")}`);
       await assertRejects(
         () => grant.getAuthenticatedClient(request),
-        InvalidClient,
+        InvalidClientError,
         "client authentication failed",
       );
 

--- a/grants/password.ts
+++ b/grants/password.ts
@@ -4,7 +4,7 @@ import {
   GrantOptions,
   GrantServices,
 } from "./grant.ts";
-import { InvalidGrant, InvalidRequest } from "../errors.ts";
+import { InvalidGrantError, InvalidRequestError } from "../errors.ts";
 import { Scope as DefaultScope, ScopeInterface } from "../models/scope.ts";
 import { UserServiceInterface } from "../services/user.ts";
 import { OAuth2Request } from "../context.ts";
@@ -57,23 +57,25 @@ export class PasswordGrant<
     request: OAuth2Request<Client, User, Scope>,
     client: Client,
   ): Promise<Token<Client, User, Scope>> {
-    if (!request.hasBody) throw new InvalidRequest("request body required");
+    if (!request.hasBody) {
+      throw new InvalidRequestError("request body required");
+    }
 
     const body: URLSearchParams = await request.body!;
     const scopeText: string | null = body.get("scope");
     let scope: Scope | null | undefined = this.parseScope(scopeText);
 
     const username: string | null = body.get("username");
-    if (!username) throw new InvalidRequest("username parameter required");
+    if (!username) throw new InvalidRequestError("username parameter required");
     const password: string | null = body.get("password");
-    if (!password) throw new InvalidRequest("password parameter required");
+    if (!password) throw new InvalidRequestError("password parameter required");
 
     const { tokenService, userService } = this.services;
     const user: User | void = await userService.getAuthenticated(
       username,
       password,
     );
-    if (!user) throw new InvalidGrant("user authentication failed");
+    if (!user) throw new InvalidGrantError("user authentication failed");
 
     scope = await this.acceptedScope(client, user, scope);
 

--- a/grants/password_test.ts
+++ b/grants/password_test.ts
@@ -16,9 +16,9 @@ import {
   TestSuite,
 } from "../test_deps.ts";
 import {
-  InvalidGrant,
-  InvalidRequest,
-  InvalidScope,
+  InvalidGrantError,
+  InvalidRequestError,
+  InvalidScopeError,
   ServerError,
 } from "../errors.ts";
 import { fakeTokenRequest } from "../test_context.ts";
@@ -104,7 +104,7 @@ test(tokenTests, "request body required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "request body required",
   );
 });
@@ -118,14 +118,14 @@ test(tokenTests, "invalid scope", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidScope,
+    InvalidScopeError,
     "invalid scope",
   );
 
   request = fakeTokenRequest("scope= ");
   await assertRejects(
     () => passwordGrant.token(request, client),
-    InvalidScope,
+    InvalidScopeError,
     "invalid scope",
   );
 });
@@ -139,14 +139,14 @@ test(tokenTests, "username parameter required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "username parameter required",
   );
 
   request = fakeTokenRequest("username=");
   await assertRejects(
     () => passwordGrant.token(request, client),
-    InvalidRequest,
+    InvalidRequestError,
     "username parameter required",
   );
 });
@@ -160,14 +160,14 @@ test(tokenTests, "password parameter required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "password parameter required",
   );
 
   request = fakeTokenRequest("username=kyle&password=");
   await assertRejects(
     () => passwordGrant.token(request, client),
-    InvalidRequest,
+    InvalidRequestError,
     "password parameter required",
   );
 });
@@ -189,7 +189,7 @@ test(tokenTests, "user authentication failed", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "user authentication failed",
     );
     assertStrictEquals(getAuthenticated.calls.length, 1);
@@ -211,7 +211,7 @@ test(tokenTests, "scope not accepted", async () => {
   const acceptedScope = stub(
     passwordGrant,
     "acceptedScope",
-    () => Promise.reject(new InvalidScope("invalid scope")),
+    () => Promise.reject(new InvalidScopeError("invalid scope")),
   );
   try {
     const request = fakeTokenRequest(
@@ -224,7 +224,7 @@ test(tokenTests, "scope not accepted", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidScope,
+      InvalidScopeError,
       "invalid scope",
     );
 

--- a/grants/refresh_token_test.ts
+++ b/grants/refresh_token_test.ts
@@ -22,9 +22,9 @@ import {
   RefreshTokenService,
 } from "../services/test_services.ts";
 import {
-  InvalidClient,
-  InvalidGrant,
-  InvalidRequest,
+  InvalidClientError,
+  InvalidGrantError,
+  InvalidRequestError,
   ServerError,
 } from "../errors.ts";
 import { fakeTokenRequest } from "../test_context.ts";
@@ -100,7 +100,7 @@ test(tokenTests, "request body required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "request body required",
   );
 });
@@ -114,14 +114,14 @@ test(tokenTests, "refresh_token parameter required", async () => {
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
     () => result,
-    InvalidRequest,
+    InvalidRequestError,
     "refresh_token parameter required",
   );
 
   request = fakeTokenRequest("refresh_token=");
   await assertRejects(
     () => refreshTokenGrant.token(request, client),
-    InvalidRequest,
+    InvalidRequestError,
     "refresh_token parameter required",
   );
 });
@@ -144,7 +144,7 @@ test(tokenTests, "invalid refresh_token", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "invalid refresh_token",
     );
     assertStrictEquals(getRefreshToken.calls.length, 1);
@@ -155,7 +155,7 @@ test(tokenTests, "invalid refresh_token", async () => {
     request = fakeTokenRequest("refresh_token=example2");
     await assertRejects(
       () => refreshTokenGrant.token(request, client),
-      InvalidGrant,
+      InvalidGrantError,
       "invalid refresh_token",
     );
     assertStrictEquals(getRefreshToken.calls.length, 2);
@@ -190,7 +190,7 @@ test(tokenTests, "expired refresh_token", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidGrant,
+      InvalidGrantError,
       "invalid refresh_token",
     );
     assertSpyCall(getRefreshToken, 0, {
@@ -225,7 +225,7 @@ test(tokenTests, "refresh_token was issued to another client", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     await assertRejects(
       () => result,
-      InvalidClient,
+      InvalidClientError,
       "refresh_token was issued to another client",
     );
     assertStrictEquals(getRefreshToken.calls.length, 1);
@@ -236,7 +236,7 @@ test(tokenTests, "refresh_token was issued to another client", async () => {
     request = fakeTokenRequest("refresh_token=example2");
     await assertRejects(
       () => refreshTokenGrant.token(request, client),
-      InvalidClient,
+      InvalidClientError,
       "refresh_token was issued to another client",
     );
     assertStrictEquals(getRefreshToken.calls.length, 2);

--- a/models/scope.ts
+++ b/models/scope.ts
@@ -1,5 +1,5 @@
 import { NQCHAR } from "../common.ts";
-import { InvalidScope } from "../errors.ts";
+import { InvalidScopeError } from "../errors.ts";
 
 export const SCOPE = new RegExp(
   `^(?:(?:${NQCHAR.source}+)(?: ${NQCHAR.source}+)*)?$`,
@@ -53,7 +53,7 @@ export class Scope implements ScopeInterface {
 
   constructor(scope?: string) {
     if (scope && !SCOPE.test(scope)) {
-      throw new InvalidScope("invalid scope");
+      throw new InvalidScopeError("invalid scope");
     }
     this.tokens = scope ? new Set(scope.match(SCOPE_TOKEN)) : new Set();
   }

--- a/models/scope_test.ts
+++ b/models/scope_test.ts
@@ -6,7 +6,7 @@ import {
   test,
   TestSuite,
 } from "../test_deps.ts";
-import { InvalidScope } from "../errors.ts";
+import { InvalidScopeError } from "../errors.ts";
 
 test("SCOPE", () => {
   assertStrictEquals(SCOPE.test(""), true);
@@ -41,18 +41,22 @@ const scopeTests: TestSuite<void> = new TestSuite({ name: "Scope" });
 
 test(scopeTests, "constructor validation", () => {
   new Scope("a");
-  assertThrows(() => new Scope(" "), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope(" a"), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope("a "), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope("a  b"), InvalidScope, "invalid scope");
+  assertThrows(() => new Scope(" "), InvalidScopeError, "invalid scope");
+  assertThrows(() => new Scope(" a"), InvalidScopeError, "invalid scope");
+  assertThrows(() => new Scope("a "), InvalidScopeError, "invalid scope");
+  assertThrows(() => new Scope("a  b"), InvalidScopeError, "invalid scope");
   new Scope("a b a c");
   new Scope("!#0A[]a~ !#1B[]b~ !#0A[]a~ !#2C[]c~");
-  assertThrows(() => new Scope('"'), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope('a"b'), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope('a b"ca d'), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope("\\"), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope("a\\b"), InvalidScope, "invalid scope");
-  assertThrows(() => new Scope("a b\\c a d"), InvalidScope, "invalid scope");
+  assertThrows(() => new Scope('"'), InvalidScopeError, "invalid scope");
+  assertThrows(() => new Scope('a"b'), InvalidScopeError, "invalid scope");
+  assertThrows(() => new Scope('a b"ca d'), InvalidScopeError, "invalid scope");
+  assertThrows(() => new Scope("\\"), InvalidScopeError, "invalid scope");
+  assertThrows(() => new Scope("a\\b"), InvalidScopeError, "invalid scope");
+  assertThrows(
+    () => new Scope("a b\\c a d"),
+    InvalidScopeError,
+    "invalid scope",
+  );
 });
 
 test(scopeTests, "toString", () => {

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -7,9 +7,9 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.110.0/testing/asserts.ts";
-export { delay } from "https://deno.land/std@0.110.0/async/delay.ts";
-export { v4 } from "https://deno.land/std@0.110.0/uuid/mod.ts";
+} from "https://deno.land/std@0.111.0/testing/asserts.ts";
+export { delay } from "https://deno.land/std@0.111.0/async/delay.ts";
+export { v4 } from "https://deno.land/std@0.111.0/uuid/mod.ts";
 
 export {
   assertSpyCall,


### PR DESCRIPTION
Closes https://github.com/udibo/oauth2_server/issues/22

I decided to keep OAuth2Error and have it extend HttpError. The classes that extend OAuth2Error now have a constructor signature similar to Error.