### PR TITLE
Add lock for refreshing tokens in example

### DIFF
--- a/authorization_server.ts
+++ b/authorization_server.ts
@@ -16,6 +16,7 @@ import {
   OAuth2AuthorizeRequest,
   OAuth2Request,
   OAuth2Response,
+  TokenBody,
 } from "./context.ts";
 import { Scope as DefaultScope, ScopeInterface } from "./models/scope.ts";
 import { AuthorizationCodeGrant } from "./grants/authorization_code.ts";
@@ -36,14 +37,6 @@ export interface AuthorizationServerOptions<
   Scope extends ScopeInterface,
 > extends ResourceServerOptions<Client, User, Scope> {
   grants: AuthorizationServerGrants<Client, User, Scope>;
-}
-
-export interface BearerToken {
-  "token_type": string;
-  "access_token": string;
-  "expires_in"?: number;
-  "refresh_token"?: string;
-  scope?: string;
 }
 
 export class AuthorizationServer<
@@ -107,8 +100,8 @@ export class AuthorizationServer<
   }
 
   /** Generates a bearer token from a token. */
-  bearerToken(token: Token<Client, User, Scope>): BearerToken {
-    const bearerToken: BearerToken = {
+  bearerToken(token: Token<Client, User, Scope>): TokenBody {
+    const bearerToken: TokenBody = {
       "token_type": "Bearer",
       "access_token": token.accessToken,
     };
@@ -144,7 +137,7 @@ export class AuthorizationServer<
   ): Promise<void> {
     await this.tokenResponse(request, response);
     const { token } = request;
-    const bearerToken: BearerToken = this.bearerToken(token);
+    const bearerToken: TokenBody = this.bearerToken(token);
     response.status = 200;
     response.body = bearerToken;
   }
@@ -399,6 +392,7 @@ export type {
   ScopeConstructor,
   ScopeInterface,
   Token,
+  TokenBody,
   TokenServiceInterface,
   User,
   UserServiceInterface,

--- a/context.ts
+++ b/context.ts
@@ -57,6 +57,14 @@ export interface OAuth2Response {
   redirect(url: string | URL): Promise<void>;
 }
 
+export interface TokenBody {
+  "token_type": string;
+  "access_token": string;
+  "expires_in"?: number;
+  "refresh_token"?: string;
+  scope?: string;
+}
+
 export interface ErrorBody {
   error: string;
   "error_description"?: string;

--- a/examples/oak-localstorage/deps.ts
+++ b/examples/oak-localstorage/deps.ts
@@ -25,20 +25,22 @@ export {
   ClientCredentialsGrant,
   generateCodeVerifier,
   loginRedirectFactory,
+  OAuth2Error,
   RefreshTokenGrant,
   Scope,
+  ServerError,
 } from "../../authorization_server.ts";
 export type {
   AccessToken,
   AuthorizationCode,
   AuthorizeParameters,
-  BearerToken,
   ClientInterface,
   LoginRedirectOptions,
   OAuth2Request,
   OAuth2Response,
   RefreshToken,
   Token,
+  TokenBody,
 } from "../../authorization_server.ts";
 
 export {

--- a/examples/oak-localstorage/main.ts
+++ b/examples/oak-localstorage/main.ts
@@ -1,12 +1,12 @@
 import {
   Application,
-  BearerToken,
   BodyForm,
   challengeMethods,
   Cookies,
   generateCodeVerifier,
   Response,
   Router,
+  TokenBody,
 } from "./deps.ts";
 import { User } from "./models/user.ts";
 import { oauth2, oauth2Router } from "./oauth2.ts";
@@ -173,7 +173,7 @@ router
             access_token: accessToken,
             refresh_token: refreshToken,
             expires_in: expiresIn,
-          } = body as BearerToken;
+          } = body as TokenBody;
           if (accessToken) session.accessToken = accessToken;
           if (refreshToken) session.refreshToken = refreshToken;
           if (expiresIn) {

--- a/resource_server.ts
+++ b/resource_server.ts
@@ -3,6 +3,7 @@ import {
   OAuth2AuthenticatedRequest,
   OAuth2Request,
   OAuth2Response,
+  TokenBody,
 } from "./context.ts";
 import {
   AccessDeniedError,
@@ -256,6 +257,7 @@ export type {
   OAuth2AuthorizeRequest,
   OAuth2Request,
   OAuth2Response,
+  TokenBody,
 } from "./context.ts";
 
 export {


### PR DESCRIPTION
Closes https://github.com/udibo/oauth2_server/issues/23

This in memory lock isn't suitable for production but neither is using localStorage. This improves the example by preventing the session's token from getting revoked if 2 resource requests come in at the same time after the access token has expired.

In addition I moved BearerToken and renamed it TokenBody to more accurately represent what the interface is for.