### PR TITLE
Allow number or BigInt client ids

### DIFF
--- a/examples/oak-localstorage/models/client.ts
+++ b/examples/oak-localstorage/models/client.ts
@@ -2,6 +2,7 @@ import { ClientInterface } from "../deps.ts";
 import { User } from "./user.ts";
 
 export interface Client extends ClientInterface {
+  id: string;
   /** Secret used for authenticating a client. */
   secret?: string | null;
   /** A user that is controlled by the client. */

--- a/grants/authorization_code.ts
+++ b/grants/authorization_code.ts
@@ -235,7 +235,7 @@ export class AuthorizationCodeGrant<
       scope,
       redirectUri: expectedRedirectUri,
     }: AuthorizationCode<Client, User, Scope> = authorizationCode;
-    if (client.id !== authorizationCodeClient.id) {
+    if (client.id.toString() !== authorizationCodeClient.id.toString()) {
       throw new InvalidClientError("code was issued to another client");
     }
 

--- a/grants/refresh_token.ts
+++ b/grants/refresh_token.ts
@@ -75,7 +75,7 @@ export class RefreshTokenGrant<
     }
 
     const { client: tokenClient, user, scope, code } = currentToken;
-    if (client.id !== tokenClient.id) {
+    if (client.id.toString() !== tokenClient.id.toString()) {
       throw new InvalidClientError(
         "refresh_token was issued to another client",
       );

--- a/models/client.ts
+++ b/models/client.ts
@@ -1,6 +1,6 @@
 export interface ClientInterface {
   /** A unique identifier. */
-  id: string;
+  id: string | number | BigInt;
   /** Grant types allowed for the client. */
   grants?: string[] | null;
   /** Redirect URIs allowed for the client. Required for the `authorization_code` grant type. */
@@ -11,5 +11,6 @@ export interface ClientInterface {
   refreshTokenLifetime?: number | null;
 }
 
-// deno-lint-ignore no-empty-interface
-export interface Client extends ClientInterface {}
+export interface Client extends ClientInterface {
+  id: string;
+}


### PR DESCRIPTION
Closes https://github.com/udibo/oauth2_server/issues/30

On the server side, we don't need to strictly limit the client id type to string. We just need to allow the client id to be string. For comparisons, client id values will first be converted to strings. If using a number or BigInt client id value, your client service get methods should accept both strings and the type of your client ids.