### PR TITLE
Upgrade oak and remove hasBody checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OAuth2 Server
 
-[![version](https://img.shields.io/badge/release-0.9.0-success)](https://deno.land/x/oauth2_server@0.9.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/oauth2_server@0.9.0/authorization_server.ts)
+[![version](https://img.shields.io/badge/release-0.10.0-success)](https://deno.land/x/oauth2_server@0.10.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/oauth2_server@0.10.0/authorization_server.ts)
 [![CI](https://github.com/udibo/oauth2_server/workflows/CI/badge.svg)](https://github.com/udibo/oauth2_server/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/oauth2_server/branch/main/graph/badge.svg?token=8Q7TSUFWUY)](https://codecov.io/gh/udibo/oauth2_server)
 [![license](https://img.shields.io/github/license/udibo/oauth2_server)](https://github.com/udibo/oauth2_server/blob/master/LICENSE)
@@ -44,9 +44,9 @@ also acting as an authorization server.
 
 ```ts
 // Import from Deno's third party module registry
-import { ResourceServer } from "https://deno.land/x/oauth2_server@0.9.0/resource_server.ts";
+import { ResourceServer } from "https://deno.land/x/oauth2_server@0.10.0/resource_server.ts";
 // Import from GitHub
-import { ResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.9.0/resource_server.ts";
+import { ResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.10.0/resource_server.ts";
 ```
 
 The AuthorizationServer is an extension of the ResourceServer, adding methods
@@ -54,9 +54,9 @@ used by the authorize and token endpoints.
 
 ```ts
 // Import from Deno's third party module registry
-import { AuthorizationServer } from "https://deno.land/x/oauth2_server@0.9.0/authorization_server.ts";
+import { AuthorizationServer } from "https://deno.land/x/oauth2_server@0.10.0/authorization_server.ts";
 // Import from GitHub
-import { AuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.9.0/authorization_server.ts";
+import { AuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.10.0/authorization_server.ts";
 ```
 
 ## Usage
@@ -66,7 +66,7 @@ An example of how to use this module can be found
 but it should give you an idea of how to use this module.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.9.0/authorization_server.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.10.0/authorization_server.ts)
 for more information.
 
 ### Grants

--- a/adapters/oak/README.md
+++ b/adapters/oak/README.md
@@ -20,9 +20,9 @@ also acting as an authorization server.
 
 ```ts
 // Import from Deno's third party module registry
-import { OakResourceServer } from "https://deno.land/x/oauth2_server@0.9.0/adapters/oak/resource_server.ts";
+import { OakResourceServer } from "https://deno.land/x/oauth2_server@0.10.0/adapters/oak/resource_server.ts";
 // Import from GitHub
-import { OakResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.9.0/adapters/oak/resource_server.ts";
+import { OakResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.10.0/adapters/oak/resource_server.ts";
 ```
 
 The AuthorizationServer is an extension of the ResourceServer, adding methods
@@ -30,9 +30,9 @@ used by the authorize and token endpoints.
 
 ```ts
 // Import from Deno's third party module registry
-import { OakAuthorizationServer } from "https://deno.land/x/oauth2_server@0.9.0/adapters/oak/authorization_server.ts";
+import { OakAuthorizationServer } from "https://deno.land/x/oauth2_server@0.10.0/adapters/oak/authorization_server.ts";
 // Import from GitHub
-import { OakAuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.9.0/adapters/oak/authorization_server.ts";
+import { OakAuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.10.0/adapters/oak/authorization_server.ts";
 ```
 
 ## Usage
@@ -42,5 +42,5 @@ An example of how to use this adapter module can be found
 but it should give you an idea of how to use this module.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.9.0/adapters/oak/authorization_server.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.10.0/adapters/oak/authorization_server.ts)
 for more information.

--- a/adapters/oak/deps.ts
+++ b/adapters/oak/deps.ts
@@ -3,8 +3,8 @@ export {
   Cookies,
   Request,
   Response,
-} from "https://deno.land/x/oak@v9.0.1/mod.ts";
+} from "https://deno.land/x/oak@v10.0.0/mod.ts";
 export type {
   BodyForm,
   Middleware,
-} from "https://deno.land/x/oak@v9.0.1/mod.ts";
+} from "https://deno.land/x/oak@v10.0.0/mod.ts";

--- a/authorization_server.ts
+++ b/authorization_server.ts
@@ -68,11 +68,7 @@ export class AuthorizationServer<
         );
       }
 
-      if (!request.hasBody) {
-        throw new InvalidRequestError("request body required");
-      }
-
-      const body: URLSearchParams = await request.body!;
+      const body: URLSearchParams = await request.body;
       const grantType: string | null = body.get("grant_type");
       if (!grantType) {
         throw new InvalidRequestError("grant_type parameter required");

--- a/authorization_server_test.ts
+++ b/authorization_server_test.ts
@@ -246,18 +246,6 @@ test(
   },
 );
 
-test(tokenTests, "request body required", async (context) => {
-  const request = fakeTokenRequest();
-  const response = fakeResponse();
-  await tokenTestError(
-    context,
-    request,
-    response,
-    InvalidRequestError,
-    "request body required",
-  );
-});
-
 test(tokenTests, "grant_type parameter required", async (context) => {
   const request = fakeTokenRequest("");
   const response = fakeResponse();

--- a/context.ts
+++ b/context.ts
@@ -11,8 +11,7 @@ export interface OAuth2Request<
   url: URL;
   headers: Headers;
   method: string;
-  hasBody: boolean;
-  body?: Promise<URLSearchParams>;
+  body: Promise<URLSearchParams>;
   token?: Token<Client, User, Scope> | null;
   accessToken?: string | null;
   authorizationCode?: AuthorizationCode<Client, User, Scope> | null;
@@ -100,7 +99,7 @@ export async function authorizeParameters<
   if (request.method === "POST") {
     const contentType: string | null = request.headers.get("content-type");
     if (
-      contentType === "application/x-www-form-urlencoded" && request.hasBody
+      contentType === "application/x-www-form-urlencoded"
     ) {
       const body: URLSearchParams = await request.body!;
       responseType = body.get("response_type");

--- a/deps.ts
+++ b/deps.ts
@@ -1,11 +1,11 @@
 export {
   decode as decodeBase64url,
   encode as encodeBase64url,
-} from "https://deno.land/std@0.114.0/encoding/base64url.ts";
+} from "https://deno.land/std@0.115.1/encoding/base64url.ts";
 export {
   encode as encodeHex,
-} from "https://deno.land/std@0.114.0/encoding/hex.ts";
-export { resolve } from "https://deno.land/std@0.114.0/path/mod.ts";
+} from "https://deno.land/std@0.115.1/encoding/hex.ts";
+export { resolve } from "https://deno.land/std@0.115.1/path/mod.ts";
 export {
   HttpError,
   isHttpError,

--- a/examples/oak-localstorage/deps.ts
+++ b/examples/oak-localstorage/deps.ts
@@ -4,12 +4,12 @@ export {
   Cookies,
   Response,
   Router,
-} from "https://deno.land/x/oak@v9.0.1/mod.ts";
-export type { BodyForm } from "https://deno.land/x/oak@v9.0.1/mod.ts";
+} from "https://deno.land/x/oak@v10.0.0/mod.ts";
+export type { BodyForm } from "https://deno.land/x/oak@v10.0.0/mod.ts";
 
 export {
   encode as encodeBase64,
-} from "https://deno.land/std@0.114.0/encoding/base64.ts";
+} from "https://deno.land/std@0.115.1/encoding/base64.ts";
 
 export {
   AbstractAccessTokenService,

--- a/examples/oak-localstorage/main.ts
+++ b/examples/oak-localstorage/main.ts
@@ -91,7 +91,7 @@ router
         cookies,
         new Error(`${sessionId ? "invalid" : "no"} session`),
       );
-    } else if (request.hasBody) {
+    } else {
       try {
         const body: BodyForm = request.body({ type: "form" });
         const form: URLSearchParams = await body.value;
@@ -132,8 +132,6 @@ router
       } catch (error) {
         showLogin(response, cookies, error);
       }
-    } else {
-      showLogin(response, cookies, new Error("no request body"));
     }
   })
   .get("/cb", async ({ request, response, cookies }) => {

--- a/examples/oak-localstorage/oauth2.ts
+++ b/examples/oak-localstorage/oauth2.ts
@@ -143,7 +143,7 @@ oauth2Router.post("/token", oauth2.token());
 const setAuthorization = async (
   request: OakOAuth2AuthorizeRequest<Client, User, Scope>,
 ): Promise<void> => {
-  if (request.method === "POST" && request.hasBody) {
+  if (request.method === "POST") {
     const body: URLSearchParams | undefined = await request.body;
     const authorizedScopeText = body?.get("authorized_scope") ?? undefined;
     if (authorizedScopeText) {

--- a/grants/authorization_code.ts
+++ b/grants/authorization_code.ts
@@ -113,13 +113,11 @@ export class AuthorizationCodeGrant<
   ): Promise<PKCEClientCredentials> {
     const clientCredentials: PKCEClientCredentials = await super
       .getClientCredentials(request);
-    if (request.hasBody) {
-      const body: URLSearchParams = await request.body!;
-      const codeVerifier: string | null = body.get("code_verifier");
-      if (codeVerifier) {
-        clientCredentials.codeVerifier = codeVerifier;
-        delete clientCredentials.clientSecret;
-      }
+    const body: URLSearchParams = await request.body;
+    const codeVerifier: string | null = body.get("code_verifier");
+    if (codeVerifier) {
+      clientCredentials.codeVerifier = codeVerifier;
+      delete clientCredentials.clientSecret;
     }
     return clientCredentials;
   }
@@ -197,10 +195,6 @@ export class AuthorizationCodeGrant<
     request: OAuth2Request<Client, User, Scope>,
     client: Client,
   ): Promise<Token<Client, User, Scope>> {
-    if (!request.hasBody) {
-      throw new InvalidRequestError("request body required");
-    }
-
     const body: URLSearchParams = await request.body!;
     const code: string | null = body.get("code");
     if (!code) {

--- a/grants/authorization_code_test.ts
+++ b/grants/authorization_code_test.ts
@@ -594,20 +594,6 @@ const tokenTests: TestSuite<void> = new TestSuite({
   suite: authorizationCodeGrantTests,
 });
 
-test(tokenTests, "request body required", async () => {
-  const request = fakeTokenRequest();
-  const result = authorizationCodeGrant.token(
-    request,
-    client,
-  );
-  assertStrictEquals(Promise.resolve(result), result);
-  await assertRejects(
-    () => result,
-    InvalidRequestError,
-    "request body required",
-  );
-});
-
 test(tokenTests, "code parameter required", async () => {
   let request = fakeTokenRequest("");
   const result = authorizationCodeGrant.token(

--- a/grants/client_credentials.ts
+++ b/grants/client_credentials.ts
@@ -1,5 +1,5 @@
 import { AbstractGrant, GrantInterface, GrantServices } from "./grant.ts";
-import { InvalidGrantError, InvalidRequestError } from "../errors.ts";
+import { InvalidGrantError } from "../errors.ts";
 import {
   Scope as DefaultScope,
   ScopeConstructor,
@@ -58,11 +58,7 @@ export class ClientCredentialsGrant<
     request: OAuth2Request<Client, User, Scope>,
     client: Client,
   ): Promise<Token<Client, User, Scope>> {
-    if (!request.hasBody) {
-      throw new InvalidRequestError("request body required");
-    }
-
-    const body: URLSearchParams = await request.body!;
+    const body: URLSearchParams = await request.body;
     const scopeText: string | null = body.get("scope");
     let scope: Scope | null | undefined = this.parseScope(scopeText);
 

--- a/grants/client_credentials_test.ts
+++ b/grants/client_credentials_test.ts
@@ -20,7 +20,6 @@ import {
 } from "../test_deps.ts";
 import {
   InvalidGrantError,
-  InvalidRequestError,
   InvalidScopeError,
   ServerError,
 } from "../errors.ts";
@@ -82,20 +81,6 @@ test(tokenTests, "not implemented for UserService", async () => {
   } finally {
     getUser.restore();
   }
-});
-
-test(tokenTests, "request body required", async () => {
-  const request = fakeTokenRequest();
-  const result = clientCredentialsGrant.token(
-    request,
-    client,
-  );
-  assertStrictEquals(Promise.resolve(result), result);
-  await assertRejects(
-    () => result,
-    InvalidRequestError,
-    "request body required",
-  );
 });
 
 test(tokenTests, "invalid scope", async () => {

--- a/grants/grant.ts
+++ b/grants/grant.ts
@@ -113,8 +113,8 @@ export abstract class AbstractGrant<
       clientId = authorization.name;
       clientSecret = authorization.pass;
     } catch (error) {
-      if (!request.headers.has("authorization") && request.hasBody) {
-        const body: URLSearchParams = await request.body!;
+      if (!request.headers.has("authorization")) {
+        const body: URLSearchParams = await request.body;
         clientId = body.get("client_id");
         clientSecret = body.get("client_secret");
       }

--- a/grants/password.ts
+++ b/grants/password.ts
@@ -57,11 +57,7 @@ export class PasswordGrant<
     request: OAuth2Request<Client, User, Scope>,
     client: Client,
   ): Promise<Token<Client, User, Scope>> {
-    if (!request.hasBody) {
-      throw new InvalidRequestError("request body required");
-    }
-
-    const body: URLSearchParams = await request.body!;
+    const body: URLSearchParams = await request.body;
     const scopeText: string | null = body.get("scope");
     let scope: Scope | null | undefined = this.parseScope(scopeText);
 

--- a/grants/password_test.ts
+++ b/grants/password_test.ts
@@ -95,20 +95,6 @@ test(tokenTests, "not implemented for UserService", async () => {
   }
 });
 
-test(tokenTests, "request body required", async () => {
-  const request = fakeTokenRequest();
-  const result = passwordGrant.token(
-    request,
-    client,
-  );
-  assertStrictEquals(Promise.resolve(result), result);
-  await assertRejects(
-    () => result,
-    InvalidRequestError,
-    "request body required",
-  );
-});
-
 test(tokenTests, "invalid scope", async () => {
   let request = fakeTokenRequest("scope=\\");
   const result = passwordGrant.token(

--- a/grants/refresh_token.ts
+++ b/grants/refresh_token.ts
@@ -54,11 +54,7 @@ export class RefreshTokenGrant<
     request: OAuth2Request<Client, User, Scope>,
     client: Client,
   ): Promise<RefreshToken<Client, User, Scope>> {
-    if (!request.hasBody) {
-      throw new InvalidRequestError("request body required");
-    }
-
-    const body: URLSearchParams = await request.body!;
+    const body: URLSearchParams = await request.body;
     const refreshToken: string | null = body.get("refresh_token");
     if (!refreshToken) {
       throw new InvalidRequestError("refresh_token parameter required");

--- a/grants/refresh_token_test.ts
+++ b/grants/refresh_token_test.ts
@@ -91,20 +91,6 @@ const refreshTokenGrant = new RefreshTokenGrant({
   },
 });
 
-test(tokenTests, "request body required", async () => {
-  const request = fakeTokenRequest();
-  const result = refreshTokenGrant.token(
-    request,
-    client,
-  );
-  assertStrictEquals(Promise.resolve(result), result);
-  await assertRejects(
-    () => result,
-    InvalidRequestError,
-    "request body required",
-  );
-});
-
 test(tokenTests, "refresh_token parameter required", async () => {
   let request = fakeTokenRequest("");
   const result = refreshTokenGrant.token(

--- a/test_context.ts
+++ b/test_context.ts
@@ -13,11 +13,14 @@ export function fakeTokenRequest(
     url: new URL("https://example.com/token"),
     headers: new Headers(),
     method: "POST",
-    hasBody: !!params,
+    get body() {
+      return Promise.resolve(params ?? new URLSearchParams());
+    },
   };
   request.headers.set("authorization", `basic ${btoa("1:")}`);
-  request.headers.set("Content-Type", "application/x-www-form-urlencoded");
-  if (params) request.body = Promise.resolve(params);
+  if (params) {
+    request.headers.set("Content-Type", "application/x-www-form-urlencoded");
+  }
   return request;
 }
 
@@ -32,14 +35,15 @@ export function fakeResourceRequest(
     url: new URL("https://example.com/resource/1"),
     headers: new Headers(),
     method: params ? "POST" : "GET",
-    hasBody: !!params,
+    get body() {
+      return Promise.resolve(params ?? new URLSearchParams());
+    },
   };
   if (bearerToken) {
     request.headers.set("authorization", `bearer ${bearerToken}`);
   }
   if (params) {
     request.headers.set("Content-Type", "application/x-www-form-urlencoded");
-    request.body = Promise.resolve(params);
   }
   return request;
 }
@@ -63,11 +67,12 @@ export function fakeAuthorizeRequest(
     url,
     headers: new Headers(),
     method: bodyParams ? "POST" : "GET",
-    hasBody: !!bodyParams,
+    get body() {
+      return Promise.resolve(bodyParams ?? new URLSearchParams());
+    },
   };
   if (bodyParams) {
     request.headers.set("Content-Type", "application/x-www-form-urlencoded");
-    request.body = Promise.resolve(bodyParams);
   }
   return request;
 }

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -8,9 +8,9 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.114.0/testing/asserts.ts";
-export { delay } from "https://deno.land/std@0.114.0/async/delay.ts";
-export { v4 } from "https://deno.land/std@0.114.0/uuid/mod.ts";
+} from "https://deno.land/std@0.115.1/testing/asserts.ts";
+export { delay } from "https://deno.land/std@0.115.1/async/delay.ts";
+export { v4 } from "https://deno.land/std@0.115.1/uuid/mod.ts";
 
 export {
   assertSpyCall,


### PR DESCRIPTION
In Oak v10.0.0, hasBody has been changed to just return true if body is not undefined and body has been made safe to call. hasBody is considered unreliable. If there isn't a body, body will return an empty body instead of throwing an error. Because of that, checking if there is a body is no longer needed.

https://deno.land/x/oak@v10.0.0#request