### PR TITLE
Refactor and remove requireRefresh from getAccessToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OAuth2 Server
 
-[![version](https://img.shields.io/badge/release-0.11.1-success)](https://deno.land/x/oauth2_server@0.11.1)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/oauth2_server@0.11.1/authorization_server.ts)
+[![version](https://img.shields.io/badge/release-0.12.0-success)](https://deno.land/x/oauth2_server@0.12.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/oauth2_server@0.12.0/authorization_server.ts)
 [![CI](https://github.com/udibo/oauth2_server/workflows/CI/badge.svg)](https://github.com/udibo/oauth2_server/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/oauth2_server/branch/main/graph/badge.svg?token=8Q7TSUFWUY)](https://codecov.io/gh/udibo/oauth2_server)
 [![license](https://img.shields.io/github/license/udibo/oauth2_server)](https://github.com/udibo/oauth2_server/blob/master/LICENSE)
@@ -44,9 +44,9 @@ also acting as an authorization server.
 
 ```ts
 // Import from Deno's third party module registry
-import { ResourceServer } from "https://deno.land/x/oauth2_server@0.11.1/resource_server.ts";
+import { ResourceServer } from "https://deno.land/x/oauth2_server@0.12.0/resource_server.ts";
 // Import from GitHub
-import { ResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.11.1/resource_server.ts";
+import { ResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.12.0/resource_server.ts";
 ```
 
 The AuthorizationServer is an extension of the ResourceServer, adding methods
@@ -54,9 +54,9 @@ used by the authorize and token endpoints.
 
 ```ts
 // Import from Deno's third party module registry
-import { AuthorizationServer } from "https://deno.land/x/oauth2_server@0.11.1/authorization_server.ts";
+import { AuthorizationServer } from "https://deno.land/x/oauth2_server@0.12.0/authorization_server.ts";
 // Import from GitHub
-import { AuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.11.1/authorization_server.ts";
+import { AuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.12.0/authorization_server.ts";
 ```
 
 ## Usage
@@ -66,7 +66,7 @@ An example of how to use this module can be found
 but it should give you an idea of how to use this module.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.11.1/authorization_server.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.12.0/authorization_server.ts)
 for more information.
 
 ### Grants

--- a/adapters/oak/README.md
+++ b/adapters/oak/README.md
@@ -20,9 +20,9 @@ also acting as an authorization server.
 
 ```ts
 // Import from Deno's third party module registry
-import { OakResourceServer } from "https://deno.land/x/oauth2_server@0.11.1/adapters/oak/resource_server.ts";
+import { OakResourceServer } from "https://deno.land/x/oauth2_server@0.12.0/adapters/oak/resource_server.ts";
 // Import from GitHub
-import { OakResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.11.1/adapters/oak/resource_server.ts";
+import { OakResourceServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.12.0/adapters/oak/resource_server.ts";
 ```
 
 The AuthorizationServer is an extension of the ResourceServer, adding methods
@@ -30,9 +30,9 @@ used by the authorize and token endpoints.
 
 ```ts
 // Import from Deno's third party module registry
-import { OakAuthorizationServer } from "https://deno.land/x/oauth2_server@0.11.1/adapters/oak/authorization_server.ts";
+import { OakAuthorizationServer } from "https://deno.land/x/oauth2_server@0.12.0/adapters/oak/authorization_server.ts";
 // Import from GitHub
-import { OakAuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.11.1/adapters/oak/authorization_server.ts";
+import { OakAuthorizationServer } from "https://raw.githubusercontent.com/udibo/oauth2_server/0.12.0/adapters/oak/authorization_server.ts";
 ```
 
 ## Usage
@@ -42,5 +42,5 @@ An example of how to use this adapter module can be found
 but it should give you an idea of how to use this module.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.11.1/adapters/oak/authorization_server.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/oauth2_server@0.12.0/adapters/oak/authorization_server.ts)
 for more information.

--- a/adapters/oak/context_test.ts
+++ b/adapters/oak/context_test.ts
@@ -4,17 +4,17 @@ import {
   assertSpyCall,
   assertSpyCalls,
   assertStrictEquals,
+  describe,
+  it,
   Spy,
   spy,
-  test,
-  TestSuite,
 } from "../../test_deps.ts";
 import { BodyForm, Context, Request, Response } from "./deps.ts";
 import { OakOAuth2Request, OakOAuth2Response } from "./context.ts";
 
-const requestTests = new TestSuite({ name: "OakOAuth2Request" });
+const requestTests = describe("OakOAuth2Request");
 
-test(requestTests, "get", async () => {
+it(requestTests, "get", async () => {
   const expectedBody = new URLSearchParams();
   const original: Request = {
     url: new URL("https://example.com/resource/1"),
@@ -35,7 +35,7 @@ test(requestTests, "get", async () => {
   assertStrictEquals(await wrapped.body, expectedBody);
 });
 
-test(requestTests, "post", async () => {
+it(requestTests, "post", async () => {
   const expectedBody: URLSearchParams = new URLSearchParams({
     grant_type: "client_credentials",
   });
@@ -58,7 +58,7 @@ test(requestTests, "post", async () => {
   assertStrictEquals(await wrapped.body, expectedBody);
 });
 
-test(requestTests, "post with sync body error", async () => {
+it(requestTests, "post with sync body error", async () => {
   const original: Request = {
     url: new URL("https://example.com/token"),
     method: "POST",
@@ -77,7 +77,7 @@ test(requestTests, "post with sync body error", async () => {
   assertEquals(await wrapped.body, new URLSearchParams());
 });
 
-test(requestTests, "post with async body error", async () => {
+it(requestTests, "post with async body error", async () => {
   const original: Request = {
     url: new URL("https://example.com/token"),
     method: "POST",
@@ -97,9 +97,9 @@ test(requestTests, "post with async body error", async () => {
   await assertRejects(() => wrapped.body, Error, "failed");
 });
 
-const responseTests = new TestSuite({ name: "OakOAuth2Response" });
+const responseTests = describe("OakOAuth2Response");
 
-test(responseTests, "redirect", () => {
+it(responseTests, "redirect", () => {
   const original: Response = {
     redirect: (_url: string | URL) => undefined,
   } as Response;
@@ -123,7 +123,7 @@ test(responseTests, "redirect", () => {
   assertSpyCalls(redirect, 2);
 });
 
-test(responseTests, "without body", () => {
+it(responseTests, "without body", () => {
   const headers: Headers = new Headers({ "Content-Type": `application/json` });
   const original: Response = {
     status: 404,
@@ -149,7 +149,7 @@ test(responseTests, "without body", () => {
   assertStrictEquals(original.body, undefined);
 });
 
-test(responseTests, "with sync body value", () => {
+it(responseTests, "with sync body value", () => {
   const headers: Headers = new Headers({ "Content-Type": `application/json` });
   const original: Response = {
     status: 200,
@@ -168,7 +168,7 @@ test(responseTests, "with sync body value", () => {
   assertStrictEquals(original.body, body);
 });
 
-test(responseTests, "with async body value", () => {
+it(responseTests, "with async body value", () => {
   const headers: Headers = new Headers({ "Content-Type": `application/json` });
   const original: Response = {
     status: 200,
@@ -189,7 +189,7 @@ test(responseTests, "with async body value", () => {
   assertStrictEquals(result, body);
 });
 
-test(responseTests, "with body function", () => {
+it(responseTests, "with body function", () => {
   const headers: Headers = new Headers({ "Content-Type": `application/json` });
   const original: Response = {
     status: 200,

--- a/adapters/oak/deps.ts
+++ b/adapters/oak/deps.ts
@@ -3,8 +3,8 @@ export {
   Cookies,
   Request,
   Response,
-} from "https://deno.land/x/oak@v10.1.0/mod.ts";
+} from "https://deno.land/x/oak@v10.5.1/mod.ts";
 export type {
   BodyForm,
   Middleware,
-} from "https://deno.land/x/oak@v10.1.0/mod.ts";
+} from "https://deno.land/x/oak@v10.5.1/mod.ts";

--- a/adapters/oak/resource_server.ts
+++ b/adapters/oak/resource_server.ts
@@ -37,7 +37,6 @@ export class OakResourceServer<
   private stateKey: string;
   private getAccessToken: (
     request: OakOAuth2Request<Client, User, Scope>,
-    requireRefresh?: boolean,
   ) => Promise<string | null>;
 
   constructor(options: OakResourceServerOptions<Client, User, Scope>) {
@@ -59,16 +58,19 @@ export class OakResourceServer<
     return state;
   }
 
+  async getToken(accessToken: string): Promise<Token<Client, User, Scope>> {
+    return await this.server.getToken(accessToken);
+  }
+
   async getTokenForRequest(
     request: OakOAuth2Request<Client, User, Scope>,
-  ): Promise<Token<Client, User, Scope> | undefined> {
-    return await this.server.getTokenForRequest(request, this.getAccessToken)
-      .catch(() => undefined);
+  ): Promise<Token<Client, User, Scope>> {
+    return await this.server.getTokenForRequest(request, this.getAccessToken);
   }
 
   async getTokenForContext(
     context: Context,
-  ): Promise<Token<Client, User, Scope> | undefined> {
+  ): Promise<Token<Client, User, Scope>> {
     const state = this.getState(context);
     const { request } = state;
     return await this.getTokenForRequest(request);

--- a/asserts_test.ts
+++ b/asserts_test.ts
@@ -3,18 +3,16 @@ import {
   assertScope,
   assertToken,
 } from "./asserts.ts";
-import { AssertionError, assertThrows, test, TestSuite } from "./test_deps.ts";
+import { AssertionError, assertThrows, describe, it } from "./test_deps.ts";
 import { Client } from "./models/client.ts";
 import { Scope } from "./models/scope.ts";
 import { Token } from "./models/token.ts";
 import { AuthorizationCode } from "./models/authorization_code.ts";
 import { User } from "./models/user.ts";
 
-const assertsTests: TestSuite<void> = new TestSuite({
-  name: "asserts",
-});
+const assertsTests = describe("asserts");
 
-test(assertsTests, "assertScope", () => {
+it(assertsTests, "assertScope", () => {
   assertScope(undefined, undefined);
   assertScope(new Scope(), new Scope());
   assertScope(new Scope("read"), new Scope("read"));
@@ -56,7 +54,7 @@ test(assertsTests, "assertScope", () => {
 const client: Client = { id: "1", grants: [] };
 const user: User = { username: "kyle" };
 
-test(assertsTests, "assertToken", () => {
+it(assertsTests, "assertToken", () => {
   const expectedToken: Token<Client, User, Scope> = {
     accessToken: "x",
     client: { id: "1", grants: [] },
@@ -169,7 +167,7 @@ test(assertsTests, "assertToken", () => {
   );
 });
 
-test(assertsTests, "assertAuthorizationCode", () => {
+it(assertsTests, "assertAuthorizationCode", () => {
   const expiresAt = new Date(Date.now() + 60000);
   const expectedAuthorizationCode: AuthorizationCode<Client, User, Scope> = {
     code: "x",

--- a/authorization_server.ts
+++ b/authorization_server.ts
@@ -366,6 +366,7 @@ export {
   UNICODECHARNOCRLF,
   UnsupportedGrantTypeError,
   UnsupportedResponseTypeError,
+  UnsupportedTokenTypeError,
   VSCHAR,
 } from "./resource_server.ts";
 export type {

--- a/authorization_server.ts
+++ b/authorization_server.ts
@@ -381,7 +381,7 @@ export type {
   OAuth2AuthenticatedRequest,
   OAuth2AuthorizedRequest,
   OAuth2AuthorizeRequest,
-  OAuth2ErrorInit,
+  OAuth2ErrorOptions,
   OAuth2Request,
   OAuth2Response,
   RefreshToken,

--- a/authorization_server_test.ts
+++ b/authorization_server_test.ts
@@ -97,6 +97,7 @@ it("verify exports", () => {
     "UnauthorizedClientError",
     "UnsupportedGrantTypeError",
     "UnsupportedResponseTypeError",
+    "UnsupportedTokenTypeError",
     "VSCHAR",
     "authorizeParameters",
     "authorizeUrl",

--- a/basic_auth_test.ts
+++ b/basic_auth_test.ts
@@ -1,12 +1,10 @@
 import { BasicAuth, parseBasicAuth } from "./basic_auth.ts";
-import { assertEquals, assertThrows, test, TestSuite } from "./test_deps.ts";
+import { assertEquals, assertThrows, describe, it } from "./test_deps.ts";
 import { InvalidClientError } from "./errors.ts";
 
-const parseBasicAuthTests: TestSuite<void> = new TestSuite({
-  name: "parseBasicAuth",
-});
+const parseBasicAuthTests = describe("parseBasicAuth");
 
-test(parseBasicAuthTests, "authorization header required", () => {
+it(parseBasicAuthTests, "authorization header required", () => {
   assertThrows(
     () => parseBasicAuth(null),
     InvalidClientError,
@@ -19,7 +17,7 @@ test(parseBasicAuthTests, "authorization header required", () => {
   );
 });
 
-test(parseBasicAuthTests, "unsupported authorization header", () => {
+it(parseBasicAuthTests, "unsupported authorization header", () => {
   assertThrows(
     () => parseBasicAuth("x"),
     InvalidClientError,
@@ -37,7 +35,7 @@ test(parseBasicAuthTests, "unsupported authorization header", () => {
   );
 });
 
-test(
+it(
   parseBasicAuthTests,
   "authorization header is not correctly encoded",
   () => {
@@ -54,7 +52,7 @@ test(
   },
 );
 
-test(parseBasicAuthTests, "authorization header is malformed", () => {
+it(parseBasicAuthTests, "authorization header is malformed", () => {
   assertThrows(
     () => parseBasicAuth(`basic ${btoa("kyle")}`),
     InvalidClientError,
@@ -72,7 +70,7 @@ test(parseBasicAuthTests, "authorization header is malformed", () => {
   );
 });
 
-test(parseBasicAuthTests, "returns correct name and pass", () => {
+it(parseBasicAuthTests, "returns correct name and pass", () => {
   let basicAuth: BasicAuth = parseBasicAuth(`basic ${btoa("kyle:")}`);
   assertEquals(basicAuth, { name: "kyle", pass: "" });
   basicAuth = parseBasicAuth(`BASIC ${btoa("kyle:hunter2")}`);

--- a/common_test.ts
+++ b/common_test.ts
@@ -1,18 +1,16 @@
 import { camelCase, snakeCase } from "./common.ts";
-import { assertStrictEquals, test, TestSuite } from "./test_deps.ts";
+import { assertStrictEquals, describe, it } from "./test_deps.ts";
 
-const commonTests: TestSuite<void> = new TestSuite({
-  name: "common",
-});
+const commonTests = describe("common");
 
-test(commonTests, "camelCase", () => {
+it(commonTests, "camelCase", () => {
   assertStrictEquals(camelCase("a_b_c"), "aBC");
   assertStrictEquals(camelCase("A-B-C"), "aBC");
   assertStrictEquals(camelCase("two_words"), "twoWords");
   assertStrictEquals(camelCase("TWO-WORDS"), "twoWords");
 });
 
-test(commonTests, "snakeCase", () => {
+it(commonTests, "snakeCase", () => {
   assertStrictEquals(snakeCase("aBC"), "a_b_c");
   assertStrictEquals(snakeCase("ABC"), "a_b_c");
   assertStrictEquals(snakeCase("twoWords"), "two_words");

--- a/context.ts
+++ b/context.ts
@@ -175,6 +175,7 @@ export interface LoginRedirectOptions {
   loginRedirectKey?: string;
 }
 
+/** Used for redirecting to login page for the authorization code flow. */
 export function loginRedirectFactory<
   Client extends ClientInterface,
   User,

--- a/context_test.ts
+++ b/context_test.ts
@@ -8,13 +8,11 @@ import { Scope } from "./models/scope.ts";
 import { User } from "./models/user.ts";
 import { challengeMethods, generateCodeVerifier } from "./pkce.ts";
 import { fakeAuthorizeRequest } from "./test_context.ts";
-import { assertEquals, test, TestSuite } from "./test_deps.ts";
+import { assertEquals, describe, it } from "./test_deps.ts";
 
-const authorizeParametersTests = new TestSuite({
-  name: "authorizeParameters",
-});
+const authorizeParametersTests = describe("authorizeParameters");
 
-test(authorizeParametersTests, "from search parameters", async () => {
+it(authorizeParametersTests, "from search parameters", async () => {
   const verifier: string = generateCodeVerifier();
   const challenge: string = await challengeMethods.S256(verifier);
   const request = fakeAuthorizeRequest();
@@ -31,7 +29,7 @@ test(authorizeParametersTests, "from search parameters", async () => {
   });
 });
 
-test(authorizeParametersTests, "from body", async () => {
+it(authorizeParametersTests, "from body", async () => {
   const verifier: string = generateCodeVerifier();
   const challenge: string = await challengeMethods.S256(verifier);
   const request = fakeAuthorizeRequest({
@@ -55,7 +53,7 @@ test(authorizeParametersTests, "from body", async () => {
   });
 });
 
-test(authorizeParametersTests, "from search parameters and body", async () => {
+it(authorizeParametersTests, "from search parameters and body", async () => {
   const verifier: string = generateCodeVerifier();
   const challenge: string = await challengeMethods.S256(verifier);
   const request = fakeAuthorizeRequest({
@@ -79,7 +77,7 @@ test(authorizeParametersTests, "from search parameters and body", async () => {
   });
 });
 
-test(
+it(
   authorizeParametersTests,
   "prefer body over search parameters",
   async () => {
@@ -121,11 +119,9 @@ test(
   },
 );
 
-const authorizeUrlTests = new TestSuite({
-  name: "authorizeUrl",
-});
+const authorizeUrlTests = describe("authorizeUrl");
 
-test(authorizeUrlTests, "without PKCE", async () => {
+it(authorizeUrlTests, "without PKCE", async () => {
   const request = fakeAuthorizeRequest();
   const expectedUrl = new URL("https://example.com/authorize");
   expectedUrl.searchParams.set("response_type", "code");
@@ -141,7 +137,7 @@ test(authorizeUrlTests, "without PKCE", async () => {
   );
 });
 
-test(authorizeUrlTests, "with PKCE", async () => {
+it(authorizeUrlTests, "with PKCE", async () => {
   const verifier: string = generateCodeVerifier();
   const challenge: string = await challengeMethods.S256(verifier);
   const request = fakeAuthorizeRequest();

--- a/deps.ts
+++ b/deps.ts
@@ -1,14 +1,14 @@
 export {
   decode as decodeBase64url,
   encode as encodeBase64url,
-} from "https://deno.land/std@0.120.0/encoding/base64url.ts";
+} from "https://deno.land/std@0.133.0/encoding/base64url.ts";
 export {
   encode as encodeHex,
-} from "https://deno.land/std@0.120.0/encoding/hex.ts";
-export { resolve } from "https://deno.land/std@0.120.0/path/mod.ts";
+} from "https://deno.land/std@0.133.0/encoding/hex.ts";
+export { resolve } from "https://deno.land/std@0.133.0/path/mod.ts";
 export {
   HttpError,
   isHttpError,
   optionsFromArgs,
-} from "https://deno.land/x/http_error@0.1.2/mod.ts";
-export type { HttpErrorInit } from "https://deno.land/x/http_error@0.1.2/mod.ts";
+} from "https://deno.land/x/http_error@0.1.3/mod.ts";
+export type { HttpErrorOptions } from "https://deno.land/x/http_error@0.1.3/mod.ts";

--- a/errors.ts
+++ b/errors.ts
@@ -1,11 +1,11 @@
 import {
   HttpError,
-  HttpErrorInit,
+  HttpErrorOptions,
   isHttpError,
   optionsFromArgs,
 } from "./deps.ts";
 
-export interface OAuth2ErrorInit extends HttpErrorInit {
+export interface OAuth2ErrorOptions extends HttpErrorOptions {
   /** An ASCII error code. */
   code?: string;
   /** A URI identifying a human readable web page with information about the error. */
@@ -21,17 +21,17 @@ export class OAuth2Error extends HttpError {
   constructor(
     status?: number,
     message?: string,
-    options?: OAuth2ErrorInit,
+    options?: OAuth2ErrorOptions,
   );
-  constructor(status?: number, options?: OAuth2ErrorInit);
-  constructor(message?: string, options?: OAuth2ErrorInit);
-  constructor(options?: OAuth2ErrorInit);
+  constructor(status?: number, options?: OAuth2ErrorOptions);
+  constructor(message?: string, options?: OAuth2ErrorOptions);
+  constructor(options?: OAuth2ErrorOptions);
   constructor(
-    statusOrMessageOrOptions?: number | string | OAuth2ErrorInit,
-    messageOrOptions?: string | OAuth2ErrorInit,
-    options?: OAuth2ErrorInit,
+    statusOrMessageOrOptions?: number | string | OAuth2ErrorOptions,
+    messageOrOptions?: string | OAuth2ErrorOptions,
+    options?: OAuth2ErrorOptions,
   ) {
-    const init: OAuth2ErrorInit = optionsFromArgs(
+    const init: OAuth2ErrorOptions = optionsFromArgs(
       statusOrMessageOrOptions,
       messageOrOptions,
       options,
@@ -53,7 +53,7 @@ export function isOAuth2Error(value: unknown): value is OAuth2Error {
  * for authenticating the client, or is otherwise malformed.
  */
 export class InvalidRequestError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "InvalidRequestError",
@@ -66,7 +66,7 @@ export class InvalidRequestError extends OAuth2Error {
 
 /** Client authentication failed. */
 export class InvalidClientError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "InvalidClientError",
@@ -82,7 +82,7 @@ export class InvalidClientError extends OAuth2Error {
  * does not match the redirection URI used in the authorization request, or was issued to another client.
  */
 export class InvalidGrantError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "InvalidGrantError",
@@ -95,20 +95,20 @@ export class InvalidGrantError extends OAuth2Error {
 
 /** The authenticated client is not authorized to use this authorization grant type. */
 export class UnauthorizedClientError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "UnauthorizedClientError",
       code: "unauthorized_client",
       status: 401,
       cause: options?.cause,
-    } as OAuth2ErrorInit);
+    } as OAuth2ErrorOptions);
   }
 }
 
 /** The authorization grant type is not supported by the authorization server. */
 export class UnsupportedGrantTypeError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "UnsupportedGrantTypeError",
@@ -121,7 +121,7 @@ export class UnsupportedGrantTypeError extends OAuth2Error {
 
 /** The resource owner or authorization server denied the request. */
 export class AccessDeniedError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "AccessDeniedError",
@@ -137,7 +137,7 @@ export class AccessDeniedError extends OAuth2Error {
  * an authorization code using this method.
  */
 export class UnsupportedResponseTypeError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "UnsupportedResponseTypeError",
@@ -150,7 +150,7 @@ export class UnsupportedResponseTypeError extends OAuth2Error {
 
 /** The requested scope is invalid, unknown, or malformed. */
 export class InvalidScopeError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "InvalidScopeError",
@@ -166,7 +166,7 @@ export class InvalidScopeError extends OAuth2Error {
  * prevented it from fulfilling the request.
  */
 export class ServerError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "ServerError",
@@ -182,7 +182,7 @@ export class ServerError extends OAuth2Error {
  * a temporary overloading or maintenance of the server.
  */
 export class TemporarilyUnavailableError extends OAuth2Error {
-  constructor(message?: string, options?: ErrorInit) {
+  constructor(message?: string, options?: ErrorOptions) {
     super({
       message,
       name: "TemporarilyUnavailableError",

--- a/errors.ts
+++ b/errors.ts
@@ -106,6 +106,19 @@ export class UnauthorizedClientError extends OAuth2Error {
   }
 }
 
+/** The token type is not supported by the authorization server. */
+export class UnsupportedTokenTypeError extends OAuth2Error {
+  constructor(message?: string, options?: ErrorOptions) {
+    super({
+      message,
+      name: "UnsupportedTokenTypeError",
+      code: "unsupported_token_type",
+      status: 400,
+      cause: options?.cause,
+    });
+  }
+}
+
 /** The authorization grant type is not supported by the authorization server. */
 export class UnsupportedGrantTypeError extends OAuth2Error {
   constructor(message?: string, options?: ErrorOptions) {

--- a/errors_test.ts
+++ b/errors_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertObjectMatch, test } from "./test_deps.ts";
+import { assertEquals, assertObjectMatch, it } from "./test_deps.ts";
 import {
   AccessDeniedError,
   InvalidClientError,
@@ -13,7 +13,7 @@ import {
   UnsupportedResponseTypeError,
 } from "./errors.ts";
 
-test("OAuth2Error", () => {
+it("OAuth2Error", () => {
   class CustomError extends OAuth2Error {}
   assertObjectMatch(new CustomError(), {
     name: "OAuth2Error",
@@ -46,7 +46,7 @@ test("OAuth2Error", () => {
   );
 });
 
-test("InvalidRequestError", () => {
+it("InvalidRequestError", () => {
   assertObjectMatch(new InvalidRequestError(), {
     name: "InvalidRequestError",
     status: 400,
@@ -72,7 +72,7 @@ test("InvalidRequestError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("InvalidClientError", () => {
+it("InvalidClientError", () => {
   assertObjectMatch(new InvalidClientError(), {
     name: "InvalidClientError",
     status: 401,
@@ -98,7 +98,7 @@ test("InvalidClientError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("InvalidGrantError", () => {
+it("InvalidGrantError", () => {
   assertObjectMatch(new InvalidGrantError(), {
     name: "InvalidGrantError",
     status: 400,
@@ -124,7 +124,7 @@ test("InvalidGrantError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("UnauthorizedClientError", () => {
+it("UnauthorizedClientError", () => {
   assertObjectMatch(new UnauthorizedClientError(), {
     name: "UnauthorizedClientError",
     status: 401,
@@ -150,7 +150,7 @@ test("UnauthorizedClientError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("UnsupportedGrantTypeError", () => {
+it("UnsupportedGrantTypeError", () => {
   assertObjectMatch(new UnsupportedGrantTypeError(), {
     name: "UnsupportedGrantTypeError",
     status: 400,
@@ -176,7 +176,7 @@ test("UnsupportedGrantTypeError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("AccessDeniedError", () => {
+it("AccessDeniedError", () => {
   assertObjectMatch(new AccessDeniedError(), {
     name: "AccessDeniedError",
     status: 401,
@@ -202,7 +202,7 @@ test("AccessDeniedError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("UnsupportedResponseTypeError", () => {
+it("UnsupportedResponseTypeError", () => {
   assertObjectMatch(new UnsupportedResponseTypeError(), {
     name: "UnsupportedResponseTypeError",
     status: 400,
@@ -228,7 +228,7 @@ test("UnsupportedResponseTypeError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("InvalidScopeError", () => {
+it("InvalidScopeError", () => {
   assertObjectMatch(new InvalidScopeError(), {
     name: "InvalidScopeError",
     status: 400,
@@ -254,7 +254,7 @@ test("InvalidScopeError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("ServerError", () => {
+it("ServerError", () => {
   assertObjectMatch(new ServerError(), {
     name: "ServerError",
     status: 500,
@@ -280,7 +280,7 @@ test("ServerError", () => {
   assertEquals(error.cause, cause);
 });
 
-test("TemporarilyUnavailableError", () => {
+it("TemporarilyUnavailableError", () => {
   assertObjectMatch(new TemporarilyUnavailableError(), {
     name: "TemporarilyUnavailableError",
     status: 503,

--- a/examples/oak-localstorage/deps.ts
+++ b/examples/oak-localstorage/deps.ts
@@ -4,12 +4,12 @@ export {
   Cookies,
   Response,
   Router,
-} from "https://deno.land/x/oak@v10.1.0/mod.ts";
-export type { BodyForm } from "https://deno.land/x/oak@v10.1.0/mod.ts";
+} from "https://deno.land/x/oak@v10.5.1/mod.ts";
+export type { BodyForm } from "https://deno.land/x/oak@v10.5.1/mod.ts";
 
 export {
   encode as encodeBase64,
-} from "https://deno.land/std@0.120.0/encoding/base64.ts";
+} from "https://deno.land/std@0.133.0/encoding/base64.ts";
 
 export {
   AbstractAccessTokenService,

--- a/examples/oak-localstorage/deps.ts
+++ b/examples/oak-localstorage/deps.ts
@@ -30,6 +30,7 @@ export {
   RefreshTokenGrant,
   Scope,
   ServerError,
+  UnsupportedTokenTypeError,
 } from "../../authorization_server.ts";
 export type {
   AccessToken,

--- a/examples/oak-localstorage/models/session.ts
+++ b/examples/oak-localstorage/models/session.ts
@@ -7,7 +7,4 @@ export interface Session {
   state?: string | null;
   redirectUri?: string | null;
   codeVerifier?: string | null;
-  accessToken?: string | null;
-  refreshToken?: string | null;
-  accessTokenExpiresAt?: Date | null;
 }

--- a/examples/oak-localstorage/oauth2.ts
+++ b/examples/oak-localstorage/oauth2.ts
@@ -8,12 +8,9 @@ import {
   OakOAuth2AuthorizeRequest,
   OakOAuth2Request,
   OakOAuth2Response,
-  OAuth2Error,
   RefreshTokenGrant,
   Router,
   Scope,
-  ServerError,
-  TokenBody,
 } from "./deps.ts";
 import { Client } from "./models/client.ts";
 import { Session } from "./models/session.ts";
@@ -58,82 +55,13 @@ async function getSession(
   return session;
 }
 
-async function refreshSession(session: Session): Promise<Session> {
-  if (!session.refreshToken) {
-    throw new ServerError("refreshSession called without refresh token");
-  }
-
-  const tokenUrl = new URL("http://localhost:8000/oauth2/token");
-  const formParams = new URLSearchParams();
-  formParams.set("grant_type", "refresh_token");
-  formParams.set("refresh_token", session.refreshToken);
-  const headers = new Headers();
-  headers.set("authorization", `basic ${btoa("1000:1234")}`); // should be environment variable
-  headers.set("content-type", "application/x-www-form-urlencoded");
-  const now = Date.now();
-  const tokenResponse = await fetch(tokenUrl, {
-    method: "POST",
-    headers,
-    body: formParams.toString(),
-  });
-  const body = await tokenResponse.json();
-  if (tokenResponse.status >= 400) {
-    if (tokenResponse.status !== 503) {
-      await sessionService.delete(session);
-    }
-    throw new OAuth2Error({
-      status: tokenResponse.status,
-      message: body.error_description,
-      code: body.error,
-      uri: body.error_uri,
-    });
-  } else if (tokenResponse.status !== 200) {
-    throw new ServerError("unexpected response from authorization server");
-  }
-
-  const {
-    access_token: accessToken,
-    refresh_token: refreshToken,
-    expires_in: expiresIn,
-  } = body as TokenBody;
-  if (accessToken) session.accessToken = accessToken;
-  if (refreshToken) session.refreshToken = refreshToken;
-  if (expiresIn) {
-    session.accessTokenExpiresAt = new Date(now + (expiresIn * 1000));
-  }
-  await sessionService.patch(session);
-
-  return session;
-}
-
-/*
-The refreshSessionPromises is being used as an in-memory lock on refreshing sessions.
-This prevents duplicate refresh token requests from being sent at the same time.
-This will not work if there are multiple resource server processes using the same sessions.
-*/
-const refreshSessionPromises = new Map<string, Promise<Session>>();
-
 export const oauth2 = new OakAuthorizationServer({
   server: oauth2Server,
   async getAccessToken(
     request: OakOAuth2Request<Client, User, Scope>,
-    requireRefresh = false,
   ): Promise<string | null> {
-    let session = await getSession(request);
-    if (requireRefresh && session?.refreshToken) {
-      const { refreshToken } = session;
-      let startedRefresh = false;
-      if (!refreshSessionPromises.has(refreshToken)) {
-        startedRefresh = true;
-        refreshSessionPromises.set(refreshToken, refreshSession(session));
-      }
-      try {
-        session = await refreshSessionPromises.get(refreshToken);
-      } finally {
-        if (startedRefresh) refreshSessionPromises.delete(refreshToken);
-      }
-    }
-    return session?.accessToken ?? null;
+    const accessToken = await request.cookies.get("accessToken");
+    return accessToken ?? null;
   },
 });
 export const oauth2Router = new Router();
@@ -152,16 +80,16 @@ const setAuthorization = async (
   }
 
   const { clientId } = request.authorizeParameters;
+  const token = await oauth2.getTokenForRequest(request)
+    .catch(() => undefined);
+  if (token) {
+    request.user = token.user;
+  }
 
-  if (clientId === "1000") {
+  if (!request.user && clientId === "1000") {
     const session = await getSession(request);
     if (session?.user) {
       request.user = session.user;
-    }
-  } else {
-    const token = await oauth2.getTokenForRequest(request);
-    if (token) {
-      request.user = token.user;
     }
   }
 };

--- a/examples/oak-localstorage/services/session.ts
+++ b/examples/oak-localstorage/services/session.ts
@@ -9,9 +9,6 @@ interface SessionInternal {
   state?: string;
   redirectUri?: string;
   codeVerifier?: string;
-  accessToken?: string;
-  refreshToken?: string;
-  accessTokenExpiresAt?: number;
 }
 
 export function saveSession(sessionId: string, session: Session): void {
@@ -32,20 +29,12 @@ export class SessionService {
       state,
       redirectUri,
       codeVerifier,
-      accessToken,
-      refreshToken,
-      accessTokenExpiresAt,
       csrf,
     } = session;
     const next: SessionInternal = { id, csrf };
     if (state) next.state = state;
     if (redirectUri) next.redirectUri = redirectUri;
     if (codeVerifier) next.codeVerifier = codeVerifier;
-    if (accessToken) next.accessToken = accessToken;
-    if (accessTokenExpiresAt) {
-      next.accessTokenExpiresAt = accessTokenExpiresAt?.valueOf();
-    }
-    if (refreshToken) next.refreshToken = refreshToken;
     if (user) next.userId = user.id;
     localStorage.setItem(`session:${id}`, JSON.stringify(next));
     return await Promise.resolve();
@@ -58,9 +47,6 @@ export class SessionService {
       state,
       redirectUri,
       codeVerifier,
-      accessToken,
-      refreshToken,
-      accessTokenExpiresAt,
       csrf,
     } = session;
     const current = await this.getInternal(id);
@@ -78,16 +64,6 @@ export class SessionService {
 
     if (codeVerifier) next.codeVerifier = codeVerifier;
     else if (codeVerifier === null) delete next.codeVerifier;
-
-    if (accessToken) next.accessToken = accessToken;
-    else if (accessToken === null) delete next.accessToken;
-
-    if (accessTokenExpiresAt) {
-      next.accessTokenExpiresAt = accessTokenExpiresAt?.valueOf();
-    } else if (accessTokenExpiresAt === null) delete next.accessTokenExpiresAt;
-
-    if (refreshToken) next.refreshToken = refreshToken;
-    else if (refreshToken === null) delete next.refreshToken;
 
     if (csrf) next.csrf = csrf;
 
@@ -116,9 +92,6 @@ export class SessionService {
       state,
       redirectUri,
       codeVerifier,
-      accessToken,
-      refreshToken,
-      accessTokenExpiresAt,
       csrf,
       userId,
     } = internal;
@@ -127,13 +100,8 @@ export class SessionService {
       state,
       redirectUri,
       codeVerifier,
-      accessToken,
-      refreshToken,
       csrf,
     };
-    if (accessTokenExpiresAt) {
-      external.accessTokenExpiresAt = new Date(accessTokenExpiresAt);
-    }
     if (userId) external.user = await this.userService.get(userId);
     return external;
   }

--- a/grants/authorization_code_test.ts
+++ b/grants/authorization_code_test.ts
@@ -12,13 +12,12 @@ import {
   assertSpyCall,
   assertSpyCalls,
   assertStrictEquals,
+  describe,
+  it,
   Spy,
   spy,
-  SpyCall,
   Stub,
   stub,
-  test,
-  TestSuite,
 } from "../test_deps.ts";
 import {
   InvalidClientError,
@@ -46,7 +45,7 @@ import {
 } from "../services/test_services.ts";
 import { User } from "../models/user.ts";
 
-const authorizationCodeGrantTests: TestSuite<void> = new TestSuite({
+const authorizationCodeGrantTests = describe({
   name: "AuthorizationCodeGrant",
 });
 
@@ -70,12 +69,12 @@ const services: AuthorizationCodeGrantServices<Client, User, Scope> = {
 };
 const authorizationCodeGrant = new AuthorizationCodeGrant({ services });
 
-const getClientCredentialsTests: TestSuite<void> = new TestSuite({
+const getClientCredentialsTests = describe({
   name: "getClientCredentials",
   suite: authorizationCodeGrantTests,
 });
 
-test(
+it(
   getClientCredentialsTests,
   "from request body without secret",
   async () => {
@@ -88,7 +87,7 @@ test(
   },
 );
 
-test(getClientCredentialsTests, "from request body with secret", async () => {
+it(getClientCredentialsTests, "from request body with secret", async () => {
   const request = fakeTokenRequest(
     "client_id=1&client_secret=2",
   );
@@ -99,7 +98,7 @@ test(getClientCredentialsTests, "from request body with secret", async () => {
   assertEquals(await result, { clientId: "1", clientSecret: "2" });
 });
 
-test(
+it(
   getClientCredentialsTests,
   "from request body with code verifier",
   async () => {
@@ -114,12 +113,12 @@ test(
   },
 );
 
-const getAuthenticatedClientTests: TestSuite<void> = new TestSuite({
+const getAuthenticatedClientTests = describe({
   name: "getAuthenticatedClient",
   suite: authorizationCodeGrantTests,
 });
 
-test(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
+it(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
   const getClientCredentials = spy(
     authorizationCodeGrant,
     "getClientCredentials",
@@ -153,7 +152,7 @@ test(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
   }
 });
 
-test(
+it(
   getAuthenticatedClientTests,
   "client authentication failed without secret",
   async () => {
@@ -197,7 +196,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "client authentication failed with secret",
   async () => {
@@ -241,7 +240,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "client authentication failed with PKCE",
   async () => {
@@ -291,7 +290,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "returns client authenticated without secret",
   async () => {
@@ -320,10 +319,11 @@ test(
 
       assertSpyCalls(clientServiceGet, 0);
 
-      const call: SpyCall = assertSpyCall(clientServiceGetAuthenticated, 0, {
+      assertSpyCall(clientServiceGetAuthenticated, 0, {
         self: clientService,
         args: ["1"],
       });
+      const call = clientServiceGetAuthenticated.calls[0];
       assertSpyCalls(clientServiceGetAuthenticated, 1);
 
       assertEquals(client, await call.returned);
@@ -335,7 +335,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "returns client authenticated with secret",
   async () => {
@@ -364,10 +364,11 @@ test(
 
       assertSpyCalls(clientServiceGet, 0);
 
-      const call: SpyCall = assertSpyCall(clientServiceGetAuthenticated, 0, {
+      assertSpyCall(clientServiceGetAuthenticated, 0, {
         self: clientService,
         args: ["1", "2"],
       });
+      const call = clientServiceGetAuthenticated.calls[0];
       assertSpyCalls(clientServiceGetAuthenticated, 1);
 
       assertEquals(client, await call.returned);
@@ -379,7 +380,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "returns client authenticated with PKCE",
   async () => {
@@ -408,10 +409,11 @@ test(
       });
       assertSpyCalls(getClientCredentials, 1);
 
-      const call = assertSpyCall(clientServiceGet, 0, {
+      assertSpyCall(clientServiceGet, 0, {
         self: clientService,
         args: ["1"],
       });
+      const call = clientServiceGet.calls[0];
       assertSpyCalls(clientServiceGet, 1);
 
       assertSpyCalls(clientServiceGetAuthenticated, 0);
@@ -425,12 +427,12 @@ test(
   },
 );
 
-const getChallengeMethodTests: TestSuite<void> = new TestSuite({
+const getChallengeMethodTests = describe({
   name: "getChallengeMethod",
   suite: authorizationCodeGrantTests,
 });
 
-test(getChallengeMethodTests, "with default challenge methods", () => {
+it(getChallengeMethodTests, "with default challenge methods", () => {
   assertStrictEquals(authorizationCodeGrant.getChallengeMethod(), undefined);
   assertStrictEquals(
     authorizationCodeGrant.getChallengeMethod("plain"),
@@ -450,7 +452,7 @@ test(getChallengeMethodTests, "with default challenge methods", () => {
   );
 });
 
-test(getChallengeMethodTests, "with custom challenge methods", () => {
+it(getChallengeMethodTests, "with custom challenge methods", () => {
   const plain: ChallengeMethod = (verifier: string) =>
     Promise.resolve(verifier);
   const other: ChallengeMethod = (verifier: string) =>
@@ -469,12 +471,12 @@ test(getChallengeMethodTests, "with custom challenge methods", () => {
   );
 });
 
-const validateChallengeMethodTests: TestSuite<void> = new TestSuite({
+const validateChallengeMethodTests = describe({
   name: "validateChallengeMethod",
   suite: authorizationCodeGrantTests,
 });
 
-test(validateChallengeMethodTests, "with default challenge methods", () => {
+it(validateChallengeMethodTests, "with default challenge methods", () => {
   assertStrictEquals(authorizationCodeGrant.validateChallengeMethod(), false);
   assertStrictEquals(
     authorizationCodeGrant.validateChallengeMethod("plain"),
@@ -494,7 +496,7 @@ test(validateChallengeMethodTests, "with default challenge methods", () => {
   );
 });
 
-test(validateChallengeMethodTests, "with custom challenge methods", () => {
+it(validateChallengeMethodTests, "with custom challenge methods", () => {
   const plain: ChallengeMethod = (verifier: string) =>
     Promise.resolve(verifier);
   const other: ChallengeMethod = (verifier: string) =>
@@ -516,12 +518,12 @@ interface VerifyCodeContext {
   authorizationCode: AuthorizationCode<Client, User, Scope>;
 }
 
-const verifyCodeTests: TestSuite<VerifyCodeContext> = new TestSuite({
+const verifyCodeTests = describe<VerifyCodeContext>({
   name: "verifyCode",
   suite: authorizationCodeGrantTests,
-  async beforeEach(context: VerifyCodeContext) {
-    context.codeVerifier = generateCodeVerifier();
-    context.authorizationCode = {
+  async beforeEach() {
+    this.codeVerifier = generateCodeVerifier();
+    this.authorizationCode = {
       code: "123",
       expiresAt: new Date(Date.now() + 60000),
       redirectUri: "https://client.example.com/cb",
@@ -529,15 +531,16 @@ const verifyCodeTests: TestSuite<VerifyCodeContext> = new TestSuite({
       user,
       scope,
       challengeMethod: "S256",
-      challenge: await challengeMethods["S256"](context.codeVerifier),
+      challenge: await challengeMethods["S256"](this.codeVerifier),
     };
   },
 });
 
-test(
+it(
   verifyCodeTests,
   "returns false if code has no challenge",
-  async ({ codeVerifier, authorizationCode }) => {
+  async function () {
+    const { codeVerifier, authorizationCode } = this;
     delete authorizationCode.challenge;
     delete authorizationCode.challengeMethod;
     assertStrictEquals(
@@ -547,22 +550,26 @@ test(
   },
 );
 
-test(
+it(
   verifyCodeTests,
   "returns false if verifier is incorrect",
-  async ({ authorizationCode }) => {
+  async function () {
     const codeVerifier: string = generateCodeVerifier();
     assertStrictEquals(
-      await authorizationCodeGrant.verifyCode(authorizationCode, codeVerifier),
+      await authorizationCodeGrant.verifyCode(
+        this.authorizationCode,
+        codeVerifier,
+      ),
       false,
     );
   },
 );
 
-test(
+it(
   verifyCodeTests,
   "returns true if verifier is correct",
-  async ({ codeVerifier, authorizationCode }) => {
+  async function () {
+    const { codeVerifier, authorizationCode } = this;
     assertStrictEquals(
       await authorizationCodeGrant.verifyCode(authorizationCode, codeVerifier),
       true,
@@ -570,10 +577,11 @@ test(
   },
 );
 
-test(
+it(
   verifyCodeTests,
   "throws if challenge method is not implemented",
-  async ({ codeVerifier, authorizationCode }) => {
+  async function () {
+    const { codeVerifier, authorizationCode } = this;
     delete authorizationCode.challengeMethod;
     await assertRejects(
       () => authorizationCodeGrant.verifyCode(authorizationCode, codeVerifier),
@@ -589,12 +597,12 @@ test(
   },
 );
 
-const tokenTests: TestSuite<void> = new TestSuite({
+const tokenTests = describe({
   name: "token",
   suite: authorizationCodeGrantTests,
 });
 
-test(tokenTests, "code parameter required", async () => {
+it(tokenTests, "code parameter required", async () => {
   let request = fakeTokenRequest("");
   const result = authorizationCodeGrant.token(
     request,
@@ -615,7 +623,7 @@ test(tokenTests, "code parameter required", async () => {
   );
 });
 
-test(tokenTests, "code already used", async () => {
+it(tokenTests, "code already used", async () => {
   const revokeCode: Stub<RefreshTokenService> = stub(
     tokenService,
     "revokeCode",
@@ -644,7 +652,7 @@ test(tokenTests, "code already used", async () => {
   }
 });
 
-test(tokenTests, "invalid code", async () => {
+it(tokenTests, "invalid code", async () => {
   const get: Stub<AuthorizationCodeService> = stub(
     authorizationCodeService,
     "get",
@@ -673,7 +681,7 @@ test(tokenTests, "invalid code", async () => {
   }
 });
 
-test(tokenTests, "expired code", async () => {
+it(tokenTests, "expired code", async () => {
   const originalGet = authorizationCodeService.get;
   const get: Stub<AuthorizationCodeService> = stub(
     authorizationCodeService,
@@ -706,7 +714,7 @@ test(tokenTests, "expired code", async () => {
   }
 });
 
-test(tokenTests, "code was issued to another client", async () => {
+it(tokenTests, "code was issued to another client", async () => {
   const originalGet = authorizationCodeService.get;
   const get: Stub<AuthorizationCodeService> = stub(
     authorizationCodeService,
@@ -739,7 +747,7 @@ test(tokenTests, "code was issued to another client", async () => {
   }
 });
 
-test(tokenTests, "redirect_uri parameter required", async () => {
+it(tokenTests, "redirect_uri parameter required", async () => {
   const get: Spy<AuthorizationCodeService> = spy(
     authorizationCodeService,
     "get",
@@ -780,7 +788,7 @@ test(tokenTests, "redirect_uri parameter required", async () => {
   }
 });
 
-test(tokenTests, "incorrect redirect_uri", async () => {
+it(tokenTests, "incorrect redirect_uri", async () => {
   const get: Spy<AuthorizationCodeService> = spy(
     authorizationCodeService,
     "get",
@@ -829,7 +837,7 @@ test(tokenTests, "incorrect redirect_uri", async () => {
   }
 });
 
-test(tokenTests, "did not expect redirect_uri parameter", async () => {
+it(tokenTests, "did not expect redirect_uri parameter", async () => {
   const originalGet = authorizationCodeService.get;
   const get: Stub<AuthorizationCodeService> = stub(
     authorizationCodeService,
@@ -866,7 +874,7 @@ test(tokenTests, "did not expect redirect_uri parameter", async () => {
   }
 });
 
-test(
+it(
   tokenTests,
   "client authentication failed with PKCE because of incorrect code_verifier",
   async () => {
@@ -916,7 +924,7 @@ test(
   },
 );
 
-test(
+it(
   tokenTests,
   "client authentication failed with PKCE because of missing code_verifier",
   async () => {
@@ -964,7 +972,7 @@ test(
   },
 );
 
-test(tokenTests, "returns token", async () => {
+it(tokenTests, "returns token", async () => {
   const get = spy(
     authorizationCodeService,
     "get",
@@ -999,13 +1007,14 @@ test(tokenTests, "returns token", async () => {
     assertStrictEquals(Promise.resolve(result), result);
     const token = await result;
 
-    const call: SpyCall = assertSpyCall(get, 0, {
+    assertSpyCall(get, 0, {
       self: authorizationCodeService,
       args: ["1"],
     });
+    const call = get.calls[0];
     assertSpyCalls(get, 1);
-    const { user, scope }: AuthorizationCode<Client, User, Scope> = await call
-      .returned;
+    const { user, scope } = await call
+      .returned as AuthorizationCode<Client, User, Scope>;
 
     assertClientUserScopeCall(
       generateToken,
@@ -1041,7 +1050,7 @@ test(tokenTests, "returns token", async () => {
   }
 });
 
-test(
+it(
   tokenTests,
   "returns token using client authenticated with PKCE",
   async () => {
@@ -1090,13 +1099,14 @@ test(
       assertStrictEquals(Promise.resolve(result), result);
       const token = await result;
 
-      const call: SpyCall = assertSpyCall(get, 0, {
+      assertSpyCall(get, 0, {
         self: authorizationCodeService,
         args: ["1"],
       });
+      const call = get.calls[0];
       assertSpyCalls(get, 1);
-      const { user, scope }: AuthorizationCode<Client, User, Scope> = await call
-        .returned;
+      const { user, scope } = await call
+        .returned as AuthorizationCode<Client, User, Scope>;
 
       assertClientUserScopeCall(
         generateToken,
@@ -1133,12 +1143,12 @@ test(
   },
 );
 
-const generateAuthorizationCodeTests: TestSuite<void> = new TestSuite({
+const generateAuthorizationCodeTests = describe({
   name: "generateAuthorizationCode",
   suite: authorizationCodeGrantTests,
 });
 
-test(generateAuthorizationCodeTests, "generateCode error", async () => {
+it(generateAuthorizationCodeTests, "generateCode error", async () => {
   const generateCode: Stub<AuthorizationCodeService> = stub(
     authorizationCodeService,
     "generateCode",
@@ -1179,7 +1189,7 @@ test(generateAuthorizationCodeTests, "generateCode error", async () => {
   }
 });
 
-test(generateAuthorizationCodeTests, "expiresAt error", async () => {
+it(generateAuthorizationCodeTests, "expiresAt error", async () => {
   const generateCode: Spy<AuthorizationCodeService> = spy(
     authorizationCodeService,
     "generateCode",
@@ -1227,7 +1237,7 @@ test(generateAuthorizationCodeTests, "expiresAt error", async () => {
   }
 });
 
-test(generateAuthorizationCodeTests, "save error", async () => {
+it(generateAuthorizationCodeTests, "save error", async () => {
   const generateCode: Stub<AuthorizationCodeService> = stub(
     authorizationCodeService,
     "generateCode",
@@ -1270,9 +1280,10 @@ test(generateAuthorizationCodeTests, "save error", async () => {
       user,
     );
     assertSpyCalls(expiresAt, 1);
-    const call: SpyCall = assertSpyCall(save, 0, {
+    assertSpyCall(save, 0, {
       self: authorizationCodeService,
     });
+    const call = save.calls[0];
     assertEquals(call.args.length, 1);
     assertAuthorizationCode(call.args[0], {
       code: "1",
@@ -1288,7 +1299,7 @@ test(generateAuthorizationCodeTests, "save error", async () => {
   }
 });
 
-test(
+it(
   generateAuthorizationCodeTests,
   "without optional properties",
   async () => {
@@ -1337,9 +1348,10 @@ test(
         user,
       );
       assertSpyCalls(expiresAt, 1);
-      const call: SpyCall = assertSpyCall(save, 0, {
+      assertSpyCall(save, 0, {
         self: authorizationCodeService,
       });
+      const call = save.calls[0];
       assertEquals(call.args.length, 1);
       assertAuthorizationCode(call.args[0], expectedAuthorizationCode);
       assertSpyCalls(save, 1);
@@ -1351,7 +1363,7 @@ test(
   },
 );
 
-test(generateAuthorizationCodeTests, "with optional properties", async () => {
+it(generateAuthorizationCodeTests, "with optional properties", async () => {
   const generateCode: Stub<AuthorizationCodeService> = stub(
     authorizationCodeService,
     "generateCode",
@@ -1409,9 +1421,10 @@ test(generateAuthorizationCodeTests, "with optional properties", async () => {
       scope,
     );
     assertSpyCalls(expiresAt, 1);
-    const call: SpyCall = assertSpyCall(save, 0, {
+    assertSpyCall(save, 0, {
       self: authorizationCodeService,
     });
+    const call = save.calls[0];
     assertEquals(call.args.length, 1);
     assertAuthorizationCode(call.args[0], expectedAuthorizationCode);
     assertSpyCalls(save, 1);

--- a/grants/client_credentials_test.ts
+++ b/grants/client_credentials_test.ts
@@ -10,13 +10,12 @@ import {
   assertRejects,
   assertSpyCalls,
   assertStrictEquals,
+  describe,
+  it,
   Spy,
   spy,
-  SpyCall,
   Stub,
   stub,
-  test,
-  TestSuite,
 } from "../test_deps.ts";
 import {
   InvalidGrantError,
@@ -33,11 +32,9 @@ import {
 } from "../services/test_services.ts";
 import { User } from "../models/user.ts";
 
-const clientCredentialsGrantTests: TestSuite<void> = new TestSuite({
-  name: "ClientCredentialsGrant",
-});
+const clientCredentialsGrantTests = describe("ClientCredentialsGrant");
 
-const tokenTests: TestSuite<void> = new TestSuite({
+const tokenTests = describe({
   name: "token",
   suite: clientCredentialsGrantTests,
 });
@@ -56,7 +53,7 @@ const services: ClientCredentialsGrantServices<Client, User, Scope> = {
 };
 const clientCredentialsGrant = new ClientCredentialsGrant({ services });
 
-test(tokenTests, "not implemented for UserService", async () => {
+it(tokenTests, "not implemented for UserService", async () => {
   const getUser: Spy<ClientService> = spy(
     clientService,
     "getUser",
@@ -74,7 +71,7 @@ test(tokenTests, "not implemented for UserService", async () => {
       "clientService.getUser not implemented",
     );
     assertStrictEquals(getUser.calls.length, 1);
-    const call: SpyCall = getUser.calls[0];
+    const call = getUser.calls[0];
     assertStrictEquals(call.self, clientService);
     assertEquals(call.args.length, 1);
     assertStrictEquals(call.args[0], client);
@@ -83,7 +80,7 @@ test(tokenTests, "not implemented for UserService", async () => {
   }
 });
 
-test(tokenTests, "invalid scope", async () => {
+it(tokenTests, "invalid scope", async () => {
   const acceptedScope = spy(clientCredentialsGrant, "acceptedScope");
   try {
     let request = fakeTokenRequest("scope=\\");
@@ -109,7 +106,7 @@ test(tokenTests, "invalid scope", async () => {
   }
 });
 
-test(tokenTests, "no user for client", async () => {
+it(tokenTests, "no user for client", async () => {
   const getUser: Stub<ClientService> = stub(
     clientService,
     "getUser",
@@ -128,7 +125,7 @@ test(tokenTests, "no user for client", async () => {
       "no user for client",
     );
     assertStrictEquals(getUser.calls.length, 1);
-    const call: SpyCall = getUser.calls[0];
+    const call = getUser.calls[0];
     assertStrictEquals(call.self, clientService);
     assertEquals(call.args.length, 1);
     assertStrictEquals(call.args[0], client);
@@ -137,7 +134,7 @@ test(tokenTests, "no user for client", async () => {
   }
 });
 
-test(tokenTests, "scope not accepted", async () => {
+it(tokenTests, "scope not accepted", async () => {
   const user = { username: "kyle" };
   const getUser = stub(
     clientService,
@@ -177,7 +174,7 @@ test(tokenTests, "scope not accepted", async () => {
   }
 });
 
-test(tokenTests, "returns accessToken", async () => {
+it(tokenTests, "returns accessToken", async () => {
   const username = "kyle";
   const getUser = stub(
     clientService,
@@ -215,11 +212,11 @@ test(tokenTests, "returns accessToken", async () => {
     const token = await result;
 
     assertStrictEquals(getUser.calls.length, 1);
-    let call: SpyCall = getUser.calls[0];
-    assertStrictEquals(call.self, clientService);
-    assertEquals(call.args.length, 1);
-    assertStrictEquals(call.args[0], client);
-    const user: User = await call.returned;
+    const getCall = getUser.calls[0];
+    assertStrictEquals(getCall.self, clientService);
+    assertEquals(getCall.args.length, 1);
+    assertStrictEquals(getCall.args[0], client);
+    const user = await getCall.returned;
 
     assertClientUserScopeCall(
       acceptedScope,
@@ -245,13 +242,13 @@ test(tokenTests, "returns accessToken", async () => {
       accessToken: "x",
       accessTokenExpiresAt,
       client,
-      user,
+      user: user!,
       scope: expectedScope,
     };
     assertStrictEquals(save.calls.length, 1);
-    call = save.calls[0];
-    assertStrictEquals(call.args.length, 1);
-    assertToken(call.args[0], expectedToken);
+    const saveCall = save.calls[0];
+    assertStrictEquals(saveCall.args.length, 1);
+    assertToken(saveCall.args[0], expectedToken);
     assertToken(token, expectedToken);
   } finally {
     getUser.restore();

--- a/grants/grant_test.ts
+++ b/grants/grant_test.ts
@@ -13,13 +13,12 @@ import {
   assertRejects,
   assertSpyCalls,
   assertStrictEquals,
+  describe,
+  it,
   Spy,
   spy,
-  SpyCall,
   Stub,
   stub,
-  test,
-  TestSuite,
 } from "../test_deps.ts";
 import { fakeTokenRequest } from "../test_context.ts";
 import { InvalidClientError, InvalidScopeError } from "../errors.ts";
@@ -30,7 +29,7 @@ import {
 } from "../services/test_services.ts";
 import { User } from "../models/user.ts";
 
-const grantTests: TestSuite<void> = new TestSuite({ name: "Grant" });
+const grantTests = describe("Grant");
 
 const clientService = new ClientService();
 const client: Client = (clientService as ClientService).client;
@@ -53,7 +52,7 @@ const refreshTokenGrant: ExampleGrant = new ExampleGrant({
   allowRefreshToken: true,
 });
 
-test(grantTests, "parseScope", () => {
+it(grantTests, "parseScope", () => {
   assertScope(grant.parseScope(undefined), undefined);
   assertScope(grant.parseScope(null), undefined);
   assertScope(grant.parseScope(""), undefined);
@@ -61,12 +60,12 @@ test(grantTests, "parseScope", () => {
   assertScope(grant.parseScope("read write"), new Scope("read write"));
 });
 
-const acceptedScopeTests: TestSuite<void> = new TestSuite({
+const acceptedScopeTests = describe({
   name: "acceptedScope",
   suite: grantTests,
 });
 
-test(
+it(
   acceptedScopeTests,
   "returns undefined if token service accepts no scope",
   async () => {
@@ -93,7 +92,7 @@ test(
   },
 );
 
-test(
+it(
   acceptedScopeTests,
   "returns scope accepted by token service without requesting scope",
   async () => {
@@ -114,7 +113,7 @@ test(
   },
 );
 
-test(
+it(
   acceptedScopeTests,
   "returns scope accepted by token service instead of requested scope",
   async () => {
@@ -145,7 +144,7 @@ test(
   },
 );
 
-test(acceptedScopeTests, "invalid scope", async () => {
+it(acceptedScopeTests, "invalid scope", async () => {
   const acceptedScope = stub(
     tokenService,
     "acceptedScope",
@@ -172,7 +171,7 @@ test(acceptedScopeTests, "invalid scope", async () => {
   }
 });
 
-test(acceptedScopeTests, "scope required", async () => {
+it(acceptedScopeTests, "scope required", async () => {
   const acceptedScope = stub(
     tokenService,
     "acceptedScope",
@@ -192,12 +191,12 @@ test(acceptedScopeTests, "scope required", async () => {
   }
 });
 
-const getClientCredentialsTests: TestSuite<void> = new TestSuite({
+const getClientCredentialsTests = describe({
   name: "getClientCredentials",
   suite: grantTests,
 });
 
-test(
+it(
   getClientCredentialsTests,
   "authorization header required if credentials not in body",
   async () => {
@@ -211,7 +210,7 @@ test(
   },
 );
 
-test(
+it(
   getClientCredentialsTests,
   "from request body without secret",
   async () => {
@@ -223,7 +222,7 @@ test(
   },
 );
 
-test(getClientCredentialsTests, "from request body with secret", async () => {
+it(getClientCredentialsTests, "from request body with secret", async () => {
   const request = fakeTokenRequest(
     "client_id=1&client_secret=2",
   );
@@ -233,7 +232,7 @@ test(getClientCredentialsTests, "from request body with secret", async () => {
   assertEquals(await result, { clientId: "1", clientSecret: "2" });
 });
 
-test(
+it(
   getClientCredentialsTests,
   "from authorization header without secret",
   async () => {
@@ -245,7 +244,7 @@ test(
   },
 );
 
-test(
+it(
   getClientCredentialsTests,
   "from authorization header with secret",
   async () => {
@@ -257,7 +256,7 @@ test(
   },
 );
 
-test(
+it(
   getClientCredentialsTests,
   "ignores request body when authorization header is present",
   async () => {
@@ -271,12 +270,12 @@ test(
   },
 );
 
-const getAuthenticatedClientTests: TestSuite<void> = new TestSuite({
+const getAuthenticatedClientTests = describe({
   name: "getAuthenticatedClient",
   suite: grantTests,
 });
 
-test(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
+it(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
   const getClientCredentials: Spy<ExampleGrant> = spy(
     grant,
     "getClientCredentials",
@@ -296,7 +295,7 @@ test(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
     );
 
     assertEquals(getClientCredentials.calls.length, 1);
-    const call: SpyCall = getClientCredentials.calls[0];
+    const call = getClientCredentials.calls[0];
     assertEquals(call.args.length, 1);
     assertStrictEquals(call.args[0], request);
     assertStrictEquals(call.self, grant);
@@ -308,7 +307,7 @@ test(getAuthenticatedClientTests, "getClientCredentials failed", async () => {
   }
 });
 
-test(
+it(
   getAuthenticatedClientTests,
   "client authentication failed without secret",
   async () => {
@@ -331,15 +330,15 @@ test(
       );
 
       assertEquals(getClientCredentials.calls.length, 1);
-      let call: SpyCall = getClientCredentials.calls[0];
-      assertEquals(call.args.length, 1);
-      assertStrictEquals(call.args[0], request);
-      assertStrictEquals(call.self, grant);
+      const getClientCredentialsCall = getClientCredentials.calls[0];
+      assertEquals(getClientCredentialsCall.args.length, 1);
+      assertStrictEquals(getClientCredentialsCall.args[0], request);
+      assertStrictEquals(getClientCredentialsCall.self, grant);
 
       assertEquals(clientServiceGetAuthenticated.calls.length, 1);
-      call = clientServiceGetAuthenticated.calls[0];
-      assertEquals(call.args, ["1"]);
-      assertStrictEquals(call.self, clientService);
+      const getAuthenticatedCall = clientServiceGetAuthenticated.calls[0];
+      assertEquals(getAuthenticatedCall.args, ["1"]);
+      assertStrictEquals(getAuthenticatedCall.self, clientService);
     } finally {
       getClientCredentials.restore();
       clientServiceGetAuthenticated.restore();
@@ -347,7 +346,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "client authentication failed with secret",
   async () => {
@@ -370,15 +369,15 @@ test(
       );
 
       assertEquals(getClientCredentials.calls.length, 1);
-      let call: SpyCall = getClientCredentials.calls[0];
-      assertEquals(call.args.length, 1);
-      assertStrictEquals(call.args[0], request);
-      assertStrictEquals(call.self, grant);
+      const getClientCredentialsCall = getClientCredentials.calls[0];
+      assertEquals(getClientCredentialsCall.args.length, 1);
+      assertStrictEquals(getClientCredentialsCall.args[0], request);
+      assertStrictEquals(getClientCredentialsCall.self, grant);
 
       assertEquals(clientServiceGetAuthenticated.calls.length, 1);
-      call = clientServiceGetAuthenticated.calls[0];
-      assertEquals(call.args, ["1", "2"]);
-      assertStrictEquals(call.self, clientService);
+      const getAuthenticatedCall = clientServiceGetAuthenticated.calls[0];
+      assertEquals(getAuthenticatedCall.args, ["1", "2"]);
+      assertStrictEquals(getAuthenticatedCall.self, clientService);
     } finally {
       getClientCredentials.restore();
       clientServiceGetAuthenticated.restore();
@@ -386,7 +385,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "returns client authenticated without secret",
   async () => {
@@ -406,17 +405,17 @@ test(
       const client = await result;
 
       assertEquals(getClientCredentials.calls.length, 1);
-      let call: SpyCall = getClientCredentials.calls[0];
-      assertEquals(call.args.length, 1);
-      assertStrictEquals(call.args[0], request);
-      assertStrictEquals(call.self, grant);
+      const getClientCredentialsCall = getClientCredentials.calls[0];
+      assertEquals(getClientCredentialsCall.args.length, 1);
+      assertStrictEquals(getClientCredentialsCall.args[0], request);
+      assertStrictEquals(getClientCredentialsCall.self, grant);
 
       assertEquals(clientServiceGetAuthenticated.calls.length, 1);
-      call = clientServiceGetAuthenticated.calls[0];
-      assertEquals(call.args, ["1"]);
-      assertStrictEquals(call.self, clientService);
+      const getAuthenticatedCall = clientServiceGetAuthenticated.calls[0];
+      assertEquals(getAuthenticatedCall.args, ["1"]);
+      assertStrictEquals(getAuthenticatedCall.self, clientService);
 
-      assertEquals(client, await call.returned);
+      assertEquals(client, await getAuthenticatedCall.returned);
     } finally {
       getClientCredentials.restore();
       clientServiceGetAuthenticated.restore();
@@ -424,7 +423,7 @@ test(
   },
 );
 
-test(
+it(
   getAuthenticatedClientTests,
   "returns client authenticated with secret",
   async () => {
@@ -444,17 +443,17 @@ test(
       const client = await result;
 
       assertEquals(getClientCredentials.calls.length, 1);
-      let call: SpyCall = getClientCredentials.calls[0];
-      assertEquals(call.args.length, 1);
-      assertStrictEquals(call.args[0], request);
-      assertStrictEquals(call.self, grant);
+      const getClientCredentialsCall = getClientCredentials.calls[0];
+      assertEquals(getClientCredentialsCall.args.length, 1);
+      assertStrictEquals(getClientCredentialsCall.args[0], request);
+      assertStrictEquals(getClientCredentialsCall.self, grant);
 
       assertEquals(clientServiceGetAuthenticated.calls.length, 1);
-      call = clientServiceGetAuthenticated.calls[0];
-      assertEquals(call.args, ["1", "2"]);
-      assertStrictEquals(call.self, clientService);
+      const getAuthenticatedCall = clientServiceGetAuthenticated.calls[0];
+      assertEquals(getAuthenticatedCall.args, ["1", "2"]);
+      assertStrictEquals(getAuthenticatedCall.self, clientService);
 
-      assertEquals(client, await call.returned);
+      assertEquals(client, await getAuthenticatedCall.returned);
     } finally {
       getClientCredentials.restore();
       clientServiceGetAuthenticated.restore();
@@ -462,14 +461,14 @@ test(
   },
 );
 
-const generateTokenTests: TestSuite<void> = new TestSuite({
+const generateTokenTests = describe({
   name: "generateToken",
   suite: grantTests,
 });
 
 const user: User = { username: "kyle" };
 
-test(
+it(
   generateTokenTests,
   "access token without optional properties",
   async () => {
@@ -509,7 +508,7 @@ test(
   },
 );
 
-test(generateTokenTests, "access token with optional properties", async () => {
+it(generateTokenTests, "access token with optional properties", async () => {
   const generateAccessToken: Stub<RefreshTokenService> = stub(
     tokenService,
     "generateAccessToken",
@@ -549,7 +548,7 @@ test(generateTokenTests, "access token with optional properties", async () => {
   }
 });
 
-test(
+it(
   generateTokenTests,
   "refresh token allowed without optional properties",
   async () => {
@@ -601,7 +600,7 @@ test(
   },
 );
 
-test(
+it(
   generateTokenTests,
   "refresh token allowed with optional properties",
   async () => {

--- a/grants/password_test.ts
+++ b/grants/password_test.ts
@@ -7,13 +7,12 @@ import {
   assertRejects,
   assertSpyCalls,
   assertStrictEquals,
+  describe,
+  it,
   Spy,
   spy,
-  SpyCall,
   Stub,
   stub,
-  test,
-  TestSuite,
 } from "../test_deps.ts";
 import {
   InvalidGrantError,
@@ -31,11 +30,11 @@ import {
 } from "../services/test_services.ts";
 import { User } from "../models/user.ts";
 
-const passwordGrantTests: TestSuite<void> = new TestSuite({
+const passwordGrantTests = describe({
   name: "PasswordGrant",
 });
 
-const tokenTests: TestSuite<void> = new TestSuite({
+const tokenTests = describe({
   name: "token",
   suite: passwordGrantTests,
 });
@@ -56,7 +55,7 @@ const services: PasswordGrantServices<Client, User, Scope> = {
 };
 const passwordGrant = new PasswordGrant({ services });
 
-test(tokenTests, "not implemented for UserService", async () => {
+it(tokenTests, "not implemented for UserService", async () => {
   const getAuthenticated: Spy<UserService> = spy(
     userService,
     "getAuthenticated",
@@ -76,7 +75,7 @@ test(tokenTests, "not implemented for UserService", async () => {
       "userService.getAuthenticated not implemented",
     );
     assertStrictEquals(getAuthenticated.calls.length, 1);
-    let call: SpyCall = getAuthenticated.calls[0];
+    let call = getAuthenticated.calls[0];
     assertStrictEquals(call.self, userService);
     assertEquals(call.args, ["kyle", "hunter2"]);
 
@@ -95,7 +94,7 @@ test(tokenTests, "not implemented for UserService", async () => {
   }
 });
 
-test(tokenTests, "invalid scope", async () => {
+it(tokenTests, "invalid scope", async () => {
   let request = fakeTokenRequest("scope=\\");
   const result = passwordGrant.token(
     request,
@@ -116,7 +115,7 @@ test(tokenTests, "invalid scope", async () => {
   );
 });
 
-test(tokenTests, "username parameter required", async () => {
+it(tokenTests, "username parameter required", async () => {
   let request = fakeTokenRequest("");
   const result = passwordGrant.token(
     request,
@@ -137,7 +136,7 @@ test(tokenTests, "username parameter required", async () => {
   );
 });
 
-test(tokenTests, "password parameter required", async () => {
+it(tokenTests, "password parameter required", async () => {
   let request = fakeTokenRequest("username=kyle");
   const result = passwordGrant.token(
     request,
@@ -158,7 +157,7 @@ test(tokenTests, "password parameter required", async () => {
   );
 });
 
-test(tokenTests, "user authentication failed", async () => {
+it(tokenTests, "user authentication failed", async () => {
   const getAuthenticated: Stub<UserService> = stub(
     userService,
     "getAuthenticated",
@@ -179,7 +178,7 @@ test(tokenTests, "user authentication failed", async () => {
       "user authentication failed",
     );
     assertStrictEquals(getAuthenticated.calls.length, 1);
-    const call: SpyCall = getAuthenticated.calls[0];
+    const call = getAuthenticated.calls[0];
     assertStrictEquals(call.self, userService);
     assertEquals(call.args, ["Kyle", "Hunter2"]);
   } finally {
@@ -187,7 +186,7 @@ test(tokenTests, "user authentication failed", async () => {
   }
 });
 
-test(tokenTests, "scope not accepted", async () => {
+it(tokenTests, "scope not accepted", async () => {
   const user = { username: "Kyle" };
   const getAuthenticated: Stub<UserService> = stub(
     userService,
@@ -229,7 +228,7 @@ test(tokenTests, "scope not accepted", async () => {
   }
 });
 
-test(tokenTests, "returns token", async () => {
+it(tokenTests, "returns token", async () => {
   const getAuthenticated = stub(
     userService,
     "getAuthenticated",
@@ -270,10 +269,10 @@ test(tokenTests, "returns token", async () => {
     const token = await result;
 
     assertStrictEquals(getAuthenticated.calls.length, 1);
-    let call: SpyCall = getAuthenticated.calls[0];
-    assertStrictEquals(call.self, userService);
-    assertEquals(call.args, ["Kyle", "Hunter2"]);
-    const user: User = await call.returned;
+    const getCall = getAuthenticated.calls[0];
+    assertStrictEquals(getCall.self, userService);
+    assertEquals(getCall.args, ["Kyle", "Hunter2"]);
+    const user = await getCall.returned;
 
     assertClientUserScopeCall(
       acceptedScope,
@@ -301,13 +300,13 @@ test(tokenTests, "returns token", async () => {
       accessTokenExpiresAt,
       refreshTokenExpiresAt,
       client,
-      user,
+      user: user!,
       scope: expectedScope,
     };
     assertStrictEquals(save.calls.length, 1);
-    call = save.calls[0];
-    assertStrictEquals(call.args.length, 1);
-    assertToken(call.args[0], expectedToken);
+    const saveCall = save.calls[0];
+    assertStrictEquals(saveCall.args.length, 1);
+    assertToken(saveCall.args[0], expectedToken);
     assertToken(token, expectedToken);
   } finally {
     getAuthenticated.restore();

--- a/grants/refresh_token_test.ts
+++ b/grants/refresh_token_test.ts
@@ -8,12 +8,11 @@ import {
   assertSpyCall,
   assertSpyCalls,
   assertStrictEquals,
+  describe,
+  it,
   spy,
-  SpyCall,
   Stub,
   stub,
-  test,
-  TestSuite,
 } from "../test_deps.ts";
 import {
   AccessTokenService,
@@ -31,18 +30,16 @@ import { fakeTokenRequest } from "../test_context.ts";
 import { assertClientUserScopeCall, assertToken } from "../asserts.ts";
 import { User } from "../models/user.ts";
 
-const refreshTokenGrantTests: TestSuite<void> = new TestSuite({
-  name: "RefreshTokenGrant",
-});
+const refreshTokenGrantTests = describe("RefreshTokenGrant");
 
-const tokenTests: TestSuite<void> = new TestSuite({
+const tokenTests = describe({
   name: "token",
   suite: refreshTokenGrantTests,
 });
 
 const clientService = new ClientService();
 
-test(tokenTests, "not implemented for AccessTokenService", async () => {
+it(tokenTests, "not implemented for AccessTokenService", async () => {
   const tokenService: AccessTokenService = new AccessTokenService();
   const getRefreshToken = spy(tokenService, "getRefreshToken");
   const refreshTokenGrant = new RefreshTokenGrant({
@@ -64,7 +61,7 @@ test(tokenTests, "not implemented for AccessTokenService", async () => {
       "getRefreshToken not implemented",
     );
     assertStrictEquals(getRefreshToken.calls.length, 1);
-    let call: SpyCall = getRefreshToken.calls[0];
+    let call = getRefreshToken.calls[0];
     assertStrictEquals(call.self, tokenService);
     assertEquals(call.args, ["example1"]);
 
@@ -91,7 +88,7 @@ const refreshTokenGrant = new RefreshTokenGrant({
   },
 });
 
-test(tokenTests, "refresh_token parameter required", async () => {
+it(tokenTests, "refresh_token parameter required", async () => {
   let request = fakeTokenRequest("");
   const result = refreshTokenGrant.token(
     request,
@@ -115,7 +112,7 @@ test(tokenTests, "refresh_token parameter required", async () => {
 const user: User = { username: "kyle" };
 const scope: Scope = new Scope("read");
 
-test(tokenTests, "invalid refresh_token", async () => {
+it(tokenTests, "invalid refresh_token", async () => {
   const getRefreshToken: Stub<RefreshTokenService> = stub(
     tokenService,
     "getRefreshToken",
@@ -134,7 +131,7 @@ test(tokenTests, "invalid refresh_token", async () => {
       "invalid refresh_token",
     );
     assertStrictEquals(getRefreshToken.calls.length, 1);
-    let call: SpyCall = getRefreshToken.calls[0];
+    let call = getRefreshToken.calls[0];
     assertStrictEquals(call.self, tokenService);
     assertEquals(call.args, ["example1"]);
 
@@ -153,7 +150,7 @@ test(tokenTests, "invalid refresh_token", async () => {
   }
 });
 
-test(tokenTests, "expired refresh_token", async () => {
+it(tokenTests, "expired refresh_token", async () => {
   const getRefreshToken: Stub<RefreshTokenService> = stub(
     tokenService,
     "getRefreshToken",
@@ -189,7 +186,7 @@ test(tokenTests, "expired refresh_token", async () => {
   }
 });
 
-test(tokenTests, "refresh_token was issued to another client", async () => {
+it(tokenTests, "refresh_token was issued to another client", async () => {
   const getRefreshToken: Stub<RefreshTokenService> = stub(
     tokenService,
     "getRefreshToken",
@@ -215,7 +212,7 @@ test(tokenTests, "refresh_token was issued to another client", async () => {
       "refresh_token was issued to another client",
     );
     assertStrictEquals(getRefreshToken.calls.length, 1);
-    let call: SpyCall = getRefreshToken.calls[0];
+    let call = getRefreshToken.calls[0];
     assertStrictEquals(call.self, tokenService);
     assertEquals(call.args, ["example1"]);
 
@@ -234,7 +231,7 @@ test(tokenTests, "refresh_token was issued to another client", async () => {
   }
 });
 
-test(tokenTests, "returns new token and revokes old", async () => {
+it(tokenTests, "returns new token and revokes old", async () => {
   const getRefreshToken = stub(
     tokenService,
     "getRefreshToken",
@@ -276,9 +273,9 @@ test(tokenTests, "returns new token and revokes old", async () => {
     const token = await result;
 
     assertStrictEquals(getRefreshToken.calls.length, 1);
-    let call: SpyCall = getRefreshToken.calls[0];
-    assertStrictEquals(call.self, tokenService);
-    assertEquals(call.args, ["example"]);
+    const getCall = getRefreshToken.calls[0];
+    assertStrictEquals(getCall.self, tokenService);
+    assertEquals(getCall.args, ["example"]);
 
     assertClientUserScopeCall(
       generateToken,
@@ -291,9 +288,9 @@ test(tokenTests, "returns new token and revokes old", async () => {
     assertSpyCalls(generateToken, 1);
 
     assertStrictEquals(revoke.calls.length, 1);
-    call = revoke.calls[0];
-    assertStrictEquals(call.args.length, 1);
-    assertToken(call.args[0], {
+    const revokeCall = revoke.calls[0];
+    assertStrictEquals(revokeCall.args.length, 1);
+    assertToken(revokeCall.args[0], {
       accessToken: "fake",
       refreshToken: "example",
       client,
@@ -311,9 +308,9 @@ test(tokenTests, "returns new token and revokes old", async () => {
       scope,
     };
     assertStrictEquals(save.calls.length, 1);
-    call = save.calls[0];
-    assertStrictEquals(call.args.length, 1);
-    assertToken(call.args[0], expectedToken);
+    const saveCall = save.calls[0];
+    assertStrictEquals(saveCall.args.length, 1);
+    assertToken(saveCall.args[0], expectedToken);
     assertToken(token, expectedToken);
   } finally {
     getRefreshToken.restore();
@@ -323,7 +320,7 @@ test(tokenTests, "returns new token and revokes old", async () => {
   }
 });
 
-test(
+it(
   tokenTests,
   "returns new token with same refresh token and revokes old",
   async () => {
@@ -364,9 +361,9 @@ test(
       const token = await result;
 
       assertStrictEquals(getRefreshToken.calls.length, 1);
-      let call: SpyCall = getRefreshToken.calls[0];
-      assertStrictEquals(call.self, tokenService);
-      assertEquals(call.args, ["example"]);
+      const getCall = getRefreshToken.calls[0];
+      assertStrictEquals(getCall.self, tokenService);
+      assertEquals(getCall.args, ["example"]);
 
       assertClientUserScopeCall(
         generateToken,
@@ -379,9 +376,9 @@ test(
       assertSpyCalls(generateToken, 1);
 
       assertStrictEquals(revoke.calls.length, 1);
-      call = revoke.calls[0];
-      assertStrictEquals(call.args.length, 1);
-      assertToken(call.args[0], {
+      const revokeCall = revoke.calls[0];
+      assertStrictEquals(revokeCall.args.length, 1);
+      assertToken(revokeCall.args[0], {
         accessToken: "fake",
         refreshToken: "example",
         refreshTokenExpiresAt,
@@ -400,9 +397,9 @@ test(
         scope,
       };
       assertStrictEquals(save.calls.length, 1);
-      call = save.calls[0];
-      assertStrictEquals(call.args.length, 1);
-      assertToken(call.args[0], expectedToken);
+      const saveCall = save.calls[0];
+      assertStrictEquals(saveCall.args.length, 1);
+      assertToken(saveCall.args[0], expectedToken);
       assertToken(token, expectedToken);
     } finally {
       getRefreshToken.restore();
@@ -413,7 +410,7 @@ test(
   },
 );
 
-test(
+it(
   tokenTests,
   "returns new token with same code and revokes old",
   async () => {
@@ -456,9 +453,9 @@ test(
       const token = await result;
 
       assertStrictEquals(getRefreshToken.calls.length, 1);
-      let call: SpyCall = getRefreshToken.calls[0];
-      assertStrictEquals(call.self, tokenService);
-      assertEquals(call.args, ["example"]);
+      const getCall = getRefreshToken.calls[0];
+      assertStrictEquals(getCall.self, tokenService);
+      assertEquals(getCall.args, ["example"]);
 
       assertClientUserScopeCall(
         generateToken,
@@ -471,9 +468,9 @@ test(
       assertSpyCalls(generateToken, 1);
 
       assertStrictEquals(revoke.calls.length, 1);
-      call = revoke.calls[0];
-      assertStrictEquals(call.args.length, 1);
-      assertToken(call.args[0], {
+      const revokeCall = revoke.calls[0];
+      assertStrictEquals(revokeCall.args.length, 1);
+      assertToken(revokeCall.args[0], {
         accessToken: "fake",
         refreshToken: "example",
         client,
@@ -493,9 +490,9 @@ test(
         code: "z",
       };
       assertStrictEquals(save.calls.length, 1);
-      call = save.calls[0];
-      assertStrictEquals(call.args.length, 1);
-      assertToken(call.args[0], expectedToken);
+      const saveCall = save.calls[0];
+      assertStrictEquals(saveCall.args.length, 1);
+      assertToken(saveCall.args[0], expectedToken);
       assertToken(token, expectedToken);
     } finally {
       getRefreshToken.restore();

--- a/models/scope_test.ts
+++ b/models/scope_test.ts
@@ -3,12 +3,12 @@ import {
   assertEquals,
   assertStrictEquals,
   assertThrows,
-  test,
-  TestSuite,
+  describe,
+  it,
 } from "../test_deps.ts";
 import { InvalidScopeError } from "../errors.ts";
 
-test("SCOPE", () => {
+it("SCOPE", () => {
   assertStrictEquals(SCOPE.test(""), true);
   assertStrictEquals(SCOPE.test("a"), true);
   assertStrictEquals(SCOPE.test(" "), false);
@@ -25,7 +25,7 @@ test("SCOPE", () => {
   assertStrictEquals(SCOPE.test("a b\\c a d"), false);
 });
 
-test("SCOPE_TOKEN", () => {
+it("SCOPE_TOKEN", () => {
   assertEquals("".match(SCOPE_TOKEN), null);
   assertEquals("a".match(SCOPE_TOKEN), ["a"]);
   assertEquals("a b a c".match(SCOPE_TOKEN), ["a", "b", "a", "c"]);
@@ -37,9 +37,9 @@ test("SCOPE_TOKEN", () => {
   ]);
 });
 
-const scopeTests: TestSuite<void> = new TestSuite({ name: "Scope" });
+const scopeTests = describe("Scope");
 
-test(scopeTests, "constructor validation", () => {
+it(scopeTests, "constructor validation", () => {
   new Scope("a");
   assertThrows(() => new Scope(" "), InvalidScopeError, "invalid scope");
   assertThrows(() => new Scope(" a"), InvalidScopeError, "invalid scope");
@@ -59,7 +59,7 @@ test(scopeTests, "constructor validation", () => {
   );
 });
 
-test(scopeTests, "toString", () => {
+it(scopeTests, "toString", () => {
   let scope = new Scope("a");
   assertStrictEquals(scope.toString(), "a");
   assertStrictEquals(scope.toString(), "a");
@@ -71,7 +71,7 @@ test(scopeTests, "toString", () => {
   assertStrictEquals(scope.toString(), "!#0A[]a~ !#1B[]b~ !#2C[]c~");
 });
 
-test(scopeTests, "toJSON", () => {
+it(scopeTests, "toJSON", () => {
   let scope = new Scope("a");
   assertStrictEquals(scope.toJSON(), "a");
   assertStrictEquals(scope.toJSON(), "a");
@@ -83,7 +83,7 @@ test(scopeTests, "toJSON", () => {
   assertStrictEquals(scope.toJSON(), "!#0A[]a~ !#1B[]b~ !#2C[]c~");
 });
 
-test(scopeTests, "from", () => {
+it(scopeTests, "from", () => {
   assertStrictEquals(Scope.from("a").toString(), "a");
   let scope: Scope = new Scope("a");
   assertStrictEquals(Scope.from(scope).toString(), "a");
@@ -106,7 +106,7 @@ test(scopeTests, "from", () => {
   assertStrictEquals(scope.toString(), "!#0A[]a~ !#1B[]b~ !#2C[]c~");
 });
 
-test(scopeTests, "has", () => {
+it(scopeTests, "has", () => {
   let scope = new Scope("a");
   assertStrictEquals(scope.has("a"), true);
   assertStrictEquals(scope.has(new Scope("a")), true);
@@ -155,7 +155,7 @@ test(scopeTests, "has", () => {
   );
 });
 
-test(scopeTests, "add", () => {
+it(scopeTests, "add", () => {
   const scope: Scope = new Scope();
   assertStrictEquals(scope.add("a"), scope);
   assertStrictEquals(scope.toString(), "a");
@@ -167,7 +167,7 @@ test(scopeTests, "add", () => {
   assertStrictEquals(scope.toString(), "a b c d e f g");
 });
 
-test(scopeTests, "remove", () => {
+it(scopeTests, "remove", () => {
   const scope: Scope = new Scope("a b c d e f g");
   assertStrictEquals(scope.remove("a"), scope);
   assertStrictEquals(scope.toString(), "b c d e f g");
@@ -179,7 +179,7 @@ test(scopeTests, "remove", () => {
   assertStrictEquals(scope.toString(), "");
 });
 
-test(scopeTests, "equals", () => {
+it(scopeTests, "equals", () => {
   let scope = new Scope("a");
   assertStrictEquals(scope.equals("a"), true);
   assertStrictEquals(scope.equals(new Scope("a")), true);
@@ -203,7 +203,7 @@ test(scopeTests, "equals", () => {
   assertStrictEquals(scope.equals(new Scope("a b c d")), false);
 });
 
-test(scopeTests, "clear", () => {
+it(scopeTests, "clear", () => {
   const scope: Scope = new Scope("a b c");
   scope.add("d");
   assertStrictEquals(scope.toString(), "a b c d");
@@ -215,7 +215,7 @@ test(scopeTests, "clear", () => {
   assertStrictEquals(scope.toString(), "");
 });
 
-test(scopeTests, "union", () => {
+it(scopeTests, "union", () => {
   const scopes: [Scope, Scope] = [
     new Scope("a b c e"),
     new Scope("b d e f"),
@@ -226,7 +226,7 @@ test(scopeTests, "union", () => {
   assertStrictEquals(scopes[1].toString(), "b d e f");
 });
 
-test(scopeTests, "intersection", () => {
+it(scopeTests, "intersection", () => {
   const scopes: [Scope, Scope] = [
     new Scope("a b c e"),
     new Scope("b d e f"),
@@ -237,6 +237,6 @@ test(scopeTests, "intersection", () => {
   assertStrictEquals(scopes[1].toString(), "b d e f");
 });
 
-test(scopeTests, "iterator", () => {
+it(scopeTests, "iterator", () => {
   assertEquals([...(new Scope("a c b d"))].sort(), ["a", "b", "c", "d"]);
 });

--- a/pkce_test.ts
+++ b/pkce_test.ts
@@ -1,11 +1,11 @@
 import { decodeBase64url } from "./deps.ts";
 import { challengeMethods, generateCodeVerifier } from "./pkce.ts";
-import { assertEquals, test, TestSuite } from "./test_deps.ts";
+import { assertEquals, describe, it } from "./test_deps.ts";
 
-const pkceTests: TestSuite<void> = new TestSuite({ name: "PKCE" });
+const pkceTests = describe("PKCE");
 
 // https://datatracker.ietf.org/doc/html/rfc7636#appendix-B
-test(pkceTests, "S256 challenge method", async () => {
+it(pkceTests, "S256 challenge method", async () => {
   const { S256 } = challengeMethods;
   assertEquals(
     await S256("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"),
@@ -13,7 +13,7 @@ test(pkceTests, "S256 challenge method", async () => {
   );
 });
 
-test(pkceTests, "generateCodeVerifier", () => {
+it(pkceTests, "generateCodeVerifier", () => {
   const encoder = new TextEncoder();
   const encoded = encoder.encode(generateCodeVerifier());
   assertEquals(encoded.length, 43);

--- a/resource_server.ts
+++ b/resource_server.ts
@@ -285,4 +285,4 @@ export {
   UnsupportedGrantTypeError,
   UnsupportedResponseTypeError,
 } from "./errors.ts";
-export type { OAuth2ErrorInit } from "./errors.ts";
+export type { OAuth2ErrorOptions } from "./errors.ts";

--- a/resource_server.ts
+++ b/resource_server.ts
@@ -126,7 +126,6 @@ export class ResourceServer<
     request: Request,
     getAccessToken: (
       request: Request,
-      requireRefresh?: boolean,
     ) => Promise<string | null>,
   ): Promise<Token<Client, User, Scope>> {
     let { token, accessToken } = request;
@@ -135,15 +134,6 @@ export class ResourceServer<
       request.accessToken = null;
       accessToken = await getAccessToken(request);
       request.accessToken = accessToken;
-      if (accessToken) {
-        try {
-          token = await this.getToken(accessToken);
-        } catch (error) {
-          if (error.code !== "access_denied") throw error;
-          accessToken = await getAccessToken(request, true);
-          request.accessToken = accessToken;
-        }
-      }
       if (!accessToken) {
         accessToken = await this.getAccessToken(request);
         request.accessToken = accessToken;
@@ -166,7 +156,6 @@ export class ResourceServer<
     next: () => Promise<unknown>,
     getAccessToken: (
       request: Request,
-      requireRefresh?: boolean,
     ) => Promise<string | null>,
     acceptedScope?: Scope,
   ): Promise<void> {
@@ -284,5 +273,6 @@ export {
   UnauthorizedClientError,
   UnsupportedGrantTypeError,
   UnsupportedResponseTypeError,
+  UnsupportedTokenTypeError,
 } from "./errors.ts";
 export type { OAuth2ErrorOptions } from "./errors.ts";

--- a/resource_server_test.ts
+++ b/resource_server_test.ts
@@ -17,12 +17,12 @@ import {
   assertSpyCall,
   assertSpyCalls,
   delay,
+  describe,
+  it,
   Spy,
   spy,
   Stub,
   stub,
-  test,
-  TestSuite,
 } from "./test_deps.ts";
 import * as resourceServerModule from "./authorization_server.ts";
 import {
@@ -40,7 +40,7 @@ import {
   User,
 } from "./authorization_server.ts";
 
-test("verify exports", () => {
+it("verify exports", () => {
   const moduleKeys = Object.keys(resourceServerModule).sort();
   assertEquals(moduleKeys, [
     "AbstractAccessTokenService",
@@ -93,16 +93,11 @@ const server = new ResourceServer({
   services: { tokenService },
 });
 
-const serverTests = new TestSuite({
-  name: "ResourceServer",
-});
+const serverTests = describe("ResourceServer");
 
-const errorHandlerTests = new TestSuite({
-  name: "errorHandler",
-  suite: serverTests,
-});
+const errorHandlerTests = describe(serverTests, "errorHandler");
 
-test(errorHandlerTests, "OAuth2Error without optional properties", async () => {
+it(errorHandlerTests, "OAuth2Error without optional properties", async () => {
   const request = fakeTokenRequest();
   const response = fakeResponse();
   const redirectSpy = spy(response, "redirect");
@@ -122,7 +117,7 @@ test(errorHandlerTests, "OAuth2Error without optional properties", async () => {
   assertEquals(redirectSpy.calls.length, 0);
 });
 
-test(errorHandlerTests, "OAuth2Error with optional properties", async () => {
+it(errorHandlerTests, "OAuth2Error with optional properties", async () => {
   const request = fakeTokenRequest();
   const response = fakeResponse();
   const redirectSpy = spy(response, "redirect");
@@ -149,7 +144,7 @@ test(errorHandlerTests, "OAuth2Error with optional properties", async () => {
   assertEquals(redirectSpy.calls.length, 0);
 });
 
-test(errorHandlerTests, "OAuth2Error with 401 status", async () => {
+it(errorHandlerTests, "OAuth2Error with 401 status", async () => {
   const request = fakeTokenRequest();
   const response = fakeResponse();
   const redirectSpy = spy(response, "redirect");
@@ -172,7 +167,7 @@ test(errorHandlerTests, "OAuth2Error with 401 status", async () => {
   assertEquals(redirectSpy.calls.length, 0);
 });
 
-test(errorHandlerTests, "Error", async () => {
+it(errorHandlerTests, "Error", async () => {
   const request = fakeTokenRequest();
   const response = fakeResponse();
   const redirectSpy = spy(response, "redirect");
@@ -193,19 +188,16 @@ test(errorHandlerTests, "Error", async () => {
   assertEquals(redirectSpy.calls.length, 0);
 });
 
-const getAccessTokenTests = new TestSuite({
-  name: "getAccessToken",
-  suite: serverTests,
-});
+const getAccessTokenTests = describe(serverTests, "getAccessToken");
 
-test(getAccessTokenTests, "GET request with no access token", async () => {
+it(getAccessTokenTests, "GET request with no access token", async () => {
   const request = fakeResourceRequest("");
   const result = server.getAccessToken(request);
   assertEquals(Promise.resolve(result), result);
   assertEquals(await result, null);
 });
 
-test(
+it(
   getAccessTokenTests,
   "GET request with access token in authorization header",
   async () => {
@@ -216,14 +208,14 @@ test(
   },
 );
 
-test(getAccessTokenTests, "POST request with no access token", async () => {
+it(getAccessTokenTests, "POST request with no access token", async () => {
   const request = fakeResourceRequest("");
   const result = server.getAccessToken(request);
   assertEquals(Promise.resolve(result), result);
   assertEquals(await result, null);
 });
 
-test(
+it(
   getAccessTokenTests,
   "POST request with access token in authorization header",
   async () => {
@@ -234,7 +226,7 @@ test(
   },
 );
 
-test(
+it(
   getAccessTokenTests,
   "POST request with access token in request body",
   async () => {
@@ -247,7 +239,7 @@ test(
   },
 );
 
-test(
+it(
   getAccessTokenTests,
   "POST request with access token in authorization header and body",
   async () => {
@@ -260,12 +252,9 @@ test(
   },
 );
 
-const getTokenTests = new TestSuite({
-  name: "getToken",
-  suite: serverTests,
-});
+const getTokenTests = describe(serverTests, "getToken");
 
-test(getTokenTests, "token service required", async () => {
+it(getTokenTests, "token service required", async () => {
   const { services } = server;
   try {
     server.services = {};
@@ -279,7 +268,7 @@ test(getTokenTests, "token service required", async () => {
   }
 });
 
-test(getTokenTests, "invalid access_token", async () => {
+it(getTokenTests, "invalid access_token", async () => {
   const getToken = stub(
     tokenService,
     "getToken",
@@ -303,7 +292,7 @@ test(getTokenTests, "invalid access_token", async () => {
   }
 });
 
-test(getTokenTests, "expired access_token", async () => {
+it(getTokenTests, "expired access_token", async () => {
   const getToken = stub(
     tokenService,
     "getToken",
@@ -334,16 +323,13 @@ test(getTokenTests, "expired access_token", async () => {
   }
 });
 
-const getTokenForRequestTests = new TestSuite({
-  name: "getTokenForRequest",
-  suite: serverTests,
-});
+const getTokenForRequestTests = describe(serverTests, "getTokenForRequest");
 
-test(
+it(
   getTokenForRequestTests,
   "authentication required from previous call",
   async () => {
-    const getCustomAccessToken = spy();
+    const getCustomAccessToken = spy(() => Promise.resolve(null));
     const getAccessToken = spy(server, "getAccessToken");
     const getToken = spy(server, "getToken");
     try {
@@ -364,11 +350,11 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "invalid access_token from previous call",
   async () => {
-    const getCustomAccessToken = spy();
+    const getCustomAccessToken = spy(() => Promise.resolve(null));
     const getAccessToken = spy(server, "getAccessToken");
     const getToken = spy(server, "getToken");
     try {
@@ -390,11 +376,11 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "returns cached token from previous call",
   async () => {
-    const getCustomAccessToken = spy();
+    const getCustomAccessToken = spy(() => Promise.resolve(null));
     const getAccessToken = spy(server, "getAccessToken");
     const getToken = spy(server, "getToken");
     try {
@@ -421,11 +407,11 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "authentication required",
   async () => {
-    const getCustomAccessToken = spy();
+    const getCustomAccessToken = spy(() => Promise.resolve(null));
     const getAccessToken = spy(server, "getAccessToken");
     const getToken = spy(server, "getToken");
     try {
@@ -457,11 +443,11 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "invalid access token",
   async () => {
-    const getCustomAccessToken = spy();
+    const getCustomAccessToken = spy(() => Promise.resolve(null));
     const getAccessToken = spy(server, "getAccessToken");
     const getToken = stub(
       server,
@@ -501,11 +487,11 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "returns token from authentication header",
   async () => {
-    const getCustomAccessToken = spy();
+    const getCustomAccessToken = spy(() => Promise.resolve(null));
     const getAccessToken = spy(server, "getAccessToken");
     const expectedToken = {
       accessToken: "123",
@@ -550,7 +536,7 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "error from custom getAccessToken",
   async () => {
@@ -583,7 +569,7 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "non access denied error for token from custom getAccessToken",
   async () => {
@@ -623,7 +609,7 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "returns token from custom getAccessToken",
   async () => {
@@ -668,7 +654,7 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "error for token from refreshed custom getAccessToken",
   async () => {
@@ -724,7 +710,7 @@ test(
   },
 );
 
-test(
+it(
   getTokenForRequestTests,
   "returns token from refreshed custom getAccessToken",
   async () => {
@@ -792,26 +778,26 @@ interface AuthenticateTestContext {
   authenticateError: Stub<ResourceServer<Client, User, Scope>>;
 }
 
-const authenticateTests = new TestSuite<AuthenticateTestContext>({
+const authenticateTests = describe<AuthenticateTestContext>({
   name: "authenticate",
   suite: serverTests,
-  beforeEach(context: AuthenticateTestContext) {
-    context.success = spy();
-    context.error = spy();
-    context.authenticateSuccess = stub(
+  beforeEach() {
+    this.success = spy();
+    this.error = spy();
+    this.authenticateSuccess = stub(
       server,
       "authenticateSuccess",
-      () => delay(0).then(context.success),
+      () => delay(0).then(this.success),
     );
-    context.authenticateError = stub(
+    this.authenticateError = stub(
       server,
       "authenticateError",
-      () => delay(0).then(context.error),
+      () => delay(0).then(this.error),
     );
   },
-  afterEach({ authenticateSuccess, authenticateError }) {
-    authenticateSuccess.restore();
-    authenticateError.restore();
+  afterEach() {
+    this.authenticateSuccess.restore();
+    this.authenticateError.restore();
   },
 });
 
@@ -835,7 +821,7 @@ async function authenticateTestError<
   msg?: string,
 ) {
   const redirect = spy(response, "redirect");
-  const next = spy();
+  const next = spy(() => Promise.resolve());
   await server.authenticate(
     request,
     response,
@@ -847,7 +833,8 @@ async function authenticateTestError<
   assertSpyCalls(authenticateSuccess, 0);
   assertSpyCalls(success, 0);
 
-  const call = assertSpyCall(authenticateError, 0, { self: server });
+  assertSpyCall(authenticateError, 0, { self: server });
+  const call = authenticateError.calls[0];
   assertEquals(call.args.length, 3);
   assertEquals(call.args.slice(0, 2), [request, response]);
   assertIsError(call.args[2], ErrorClass, msgIncludes, msg);
@@ -865,10 +852,10 @@ async function authenticateTestError<
   assertSpyCalls(next, 0);
 }
 
-test(
+it(
   authenticateTests,
   "error getting token for request",
-  async (context) => {
+  async function () {
     const getTokenForRequest = stub(
       server,
       "getTokenForRequest",
@@ -878,9 +865,9 @@ test(
     try {
       const request = fakeResourceRequest("123");
       const response = fakeResponse();
-      const getAccessToken = spy();
+      const getAccessToken = spy(() => Promise.resolve(null));
       await authenticateTestError(
-        context,
+        this,
         request,
         response,
         getAccessToken,
@@ -902,7 +889,7 @@ test(
   },
 );
 
-test(authenticateTests, "insufficient scope", async (context) => {
+it(authenticateTests, "insufficient scope", async function () {
   const expectedToken = {
     accessToken: "123",
     client,
@@ -918,10 +905,10 @@ test(authenticateTests, "insufficient scope", async (context) => {
   try {
     const request = fakeResourceRequest("123");
     const response = fakeResponse();
-    const getAccessToken = spy();
+    const getAccessToken = spy(() => Promise.resolve(null));
     const acceptedScope = new Scope("read write delete");
     await authenticateTestError(
-      context,
+      this,
       request,
       response,
       getAccessToken,
@@ -958,8 +945,8 @@ async function authenticateTest<
     () => Promise.resolve(expectedToken),
   );
   const redirect = spy(response, "redirect");
-  const next = spy();
-  const getAccessToken = spy();
+  const next = spy(() => Promise.resolve());
+  const getAccessToken = spy(() => Promise.resolve(null));
 
   try {
     await server.authenticate(
@@ -1002,7 +989,7 @@ async function authenticateTest<
   assertSpyCalls(next, 0);
 }
 
-test(authenticateTests, "without scope", async (context) => {
+it(authenticateTests, "without scope", async function () {
   const request = fakeResourceRequest("123");
   const response = fakeResponse();
   const expectedToken = {
@@ -1012,7 +999,7 @@ test(authenticateTests, "without scope", async (context) => {
     scope,
   };
   await authenticateTest(
-    context,
+    this,
     request,
     response,
     undefined,
@@ -1020,7 +1007,7 @@ test(authenticateTests, "without scope", async (context) => {
   );
 });
 
-test(authenticateTests, "with scope", async (context) => {
+it(authenticateTests, "with scope", async function () {
   const request = fakeResourceRequest("123");
   const response = fakeResponse();
   const expectedToken = {
@@ -1030,7 +1017,7 @@ test(authenticateTests, "with scope", async (context) => {
     scope,
   };
   await authenticateTest(
-    context,
+    this,
     request,
     response,
     scope,
@@ -1038,12 +1025,9 @@ test(authenticateTests, "with scope", async (context) => {
   );
 });
 
-const authenticateResponseTests = new TestSuite({
-  name: "authenticateResponse",
-  suite: serverTests,
-});
+const authenticateResponseTests = describe(serverTests, "authenticateResponse");
 
-test(authenticateResponseTests, "without accepted scope", async () => {
+it(authenticateResponseTests, "without accepted scope", async () => {
   const request = fakeResourceRequest("123");
   request.token = {
     accessToken: "123",
@@ -1063,7 +1047,7 @@ test(authenticateResponseTests, "without accepted scope", async () => {
   assertSpyCalls(redirect, 0);
 });
 
-test(authenticateResponseTests, "with accepted scope", async () => {
+it(authenticateResponseTests, "with accepted scope", async () => {
   const request = fakeResourceRequest("123");
   request.token = {
     accessToken: "123",
@@ -1084,7 +1068,7 @@ test(authenticateResponseTests, "with accepted scope", async () => {
   assertSpyCalls(redirect, 0);
 });
 
-test(authenticateResponseTests, "without scope", async () => {
+it(authenticateResponseTests, "without scope", async () => {
   const request = fakeResourceRequest("123");
   request.token = {
     accessToken: "123",
@@ -1104,7 +1088,7 @@ test(authenticateResponseTests, "without scope", async () => {
   assertSpyCalls(redirect, 0);
 });
 
-test(serverTests, "authenticateSuccess", async () => {
+it(serverTests, "authenticateSuccess", async () => {
   const authenticateResponseAwait = spy();
   const authenticateResponse = stub(
     server,
@@ -1148,7 +1132,7 @@ test(serverTests, "authenticateSuccess", async () => {
   }
 });
 
-test(serverTests, "authenticateError", async () => {
+it(serverTests, "authenticateError", async () => {
   const authenticateResponseAwait = spy();
   const authenticateResponse = stub(
     server,

--- a/services/authorization_code_test.ts
+++ b/services/authorization_code_test.ts
@@ -2,9 +2,9 @@ import {
   assert,
   assertEquals,
   assertStrictEquals,
+  describe,
   FakeTime,
-  test,
-  TestSuite,
+  it,
   v4,
 } from "../test_deps.ts";
 import {
@@ -16,11 +16,9 @@ import {
 
 const authorizationCodeService = new AuthorizationCodeService();
 
-const authorizationCodeServiceTests: TestSuite<void> = new TestSuite({
-  name: "AuthorizationCodeService",
-});
+const authorizationCodeServiceTests = describe("AuthorizationCodeService");
 
-test(authorizationCodeServiceTests, "generateAuthorizationCode", async () => {
+it(authorizationCodeServiceTests, "generateAuthorizationCode", async () => {
   const result = authorizationCodeService.generateCode(
     client,
     user,
@@ -35,7 +33,7 @@ test(authorizationCodeServiceTests, "generateAuthorizationCode", async () => {
   );
 });
 
-test(authorizationCodeServiceTests, "accessTokenExpiresAt", async () => {
+it(authorizationCodeServiceTests, "accessTokenExpiresAt", async () => {
   const time: FakeTime = new FakeTime();
   try {
     const fiveMinutes: number = 5 * 60 * 1000;

--- a/services/client_test.ts
+++ b/services/client_test.ts
@@ -1,14 +1,12 @@
-import { assertRejects, test, TestSuite } from "../test_deps.ts";
+import { assertRejects, describe, it } from "../test_deps.ts";
 import { ServerError } from "../errors.ts";
 import { client, ClientService } from "./test_services.ts";
 
 const clientService = new ClientService();
 
-const clientServiceTests: TestSuite<void> = new TestSuite({
-  name: "ClientService",
-});
+const clientServiceTests = describe("ClientService");
 
-test(clientServiceTests, "getUser", async () => {
+it(clientServiceTests, "getUser", async () => {
   await assertRejects(
     () => clientService.getUser(client),
     ServerError,

--- a/services/test_services.ts
+++ b/services/test_services.ts
@@ -51,7 +51,7 @@ export class AccessTokenService
   }
 
   /** Revokes a token. */
-  async revoke(_token: Token<Client, User, Scope>): Promise<boolean> {
+  async revoke(_token: string | Token<Client, User, Scope>): Promise<boolean> {
     return await Promise.resolve(true);
   }
 
@@ -103,7 +103,7 @@ export class RefreshTokenService
   }
 
   /** Revokes a token. */
-  async revoke(_token: Token<Client, User, Scope>): Promise<boolean> {
+  async revoke(_token: string | Token<Client, User, Scope>): Promise<boolean> {
     return await Promise.resolve(true);
   }
 

--- a/services/token.ts
+++ b/services/token.ts
@@ -52,9 +52,10 @@ export interface TokenServiceInterface<
   ): Promise<RefreshToken<Client, User, Scope> | undefined>;
   /** Saves a token. */
   save(token: Token<Client, User, Scope>): Promise<Token<Client, User, Scope>>;
-  /** Revokes a token. Resolves true if a token was revoked. */
+  /** Revokes a token. Resolves true if a token was revoked or invalid. */
   revoke(token: Token<Client, User, Scope>): Promise<boolean>;
-  /** Revokes all tokens for an authorization code. Resolves true if a token was revoked. */
+  revoke(token: string, hint?: string | null): Promise<boolean>;
+  /** Revokes all tokens for an authorization code. Resolves true if a authorization code was revoked or invalid. */
   revokeCode(code: string): Promise<boolean>;
 }
 
@@ -140,10 +141,11 @@ export abstract class AbstractAccessTokenService<
     token: AccessToken<Client, User, Scope>,
   ): Promise<AccessToken<Client, User, Scope>>;
 
-  /** Revokes a token. Resolves true if a token was revoked. */
+  /** Revokes a token. Resolves true if a token was revoked or invalid. */
   abstract revoke(token: AccessToken<Client, User, Scope>): Promise<boolean>;
+  abstract revoke(token: string, hint?: string | null): Promise<boolean>;
 
-  /** Revokes all tokens for an authorization code. Resolves true if a token was revoked. */
+  /** Revokes all tokens for an authorization code. Resolves true if a authorization code was revoked or invalid. */
   abstract revokeCode(code: string): Promise<boolean>;
 }
 
@@ -193,6 +195,7 @@ export abstract class AbstractRefreshTokenService<
     token: Token<Client, User, Scope>,
   ): Promise<Token<Client, User, Scope>>;
 
-  /** Revokes a token. Resolves true if a token was revoked. */
-  abstract revoke(token: Token<Client, User, Scope> | string): Promise<boolean>;
+  /** Revokes a token. Resolves true if a token was revoked or invalid. */
+  abstract revoke(token: Token<Client, User, Scope>): Promise<boolean>;
+  abstract revoke(token: string, hint?: string | null): Promise<boolean>;
 }

--- a/services/token_test.ts
+++ b/services/token_test.ts
@@ -4,9 +4,9 @@ import {
   assertEquals,
   assertRejects,
   assertStrictEquals,
+  describe,
   FakeTime,
-  test,
-  TestSuite,
+  it,
   v4,
 } from "../test_deps.ts";
 import { ServerError } from "../errors.ts";
@@ -20,11 +20,9 @@ import {
 
 const accessTokenService = new AccessTokenService();
 
-const accessTokenServiceTests: TestSuite<void> = new TestSuite({
-  name: "AccessTokenService",
-});
+const accessTokenServiceTests = describe("AccessTokenService");
 
-test(accessTokenServiceTests, "generateAccessToken", async () => {
+it(accessTokenServiceTests, "generateAccessToken", async () => {
   const result = accessTokenService.generateAccessToken(
     client,
     user,
@@ -39,7 +37,7 @@ test(accessTokenServiceTests, "generateAccessToken", async () => {
   );
 });
 
-test(
+it(
   accessTokenServiceTests,
   "generateRefreshToken not implemented",
   async () => {
@@ -59,7 +57,7 @@ test(
   },
 );
 
-test(accessTokenServiceTests, "accessTokenExpiresAt", async () => {
+it(accessTokenServiceTests, "accessTokenExpiresAt", async () => {
   const time: FakeTime = new FakeTime();
   try {
     const hour: number = 60 * 60 * 1000;
@@ -80,7 +78,7 @@ test(accessTokenServiceTests, "accessTokenExpiresAt", async () => {
   }
 });
 
-test(
+it(
   accessTokenServiceTests,
   "accessTokenExpiresAt with client.accessTokenLifetime",
   async () => {
@@ -114,7 +112,7 @@ test(
   },
 );
 
-test(
+it(
   accessTokenServiceTests,
   "refreshTokenExpiresAt not implemented",
   async () => {
@@ -134,7 +132,7 @@ test(
   },
 );
 
-test(accessTokenServiceTests, "getRefreshToken not implemented", async () => {
+it(accessTokenServiceTests, "getRefreshToken not implemented", async () => {
   const result = accessTokenService.getRefreshToken("fake");
   assertStrictEquals(Promise.resolve(result), result);
   await assertRejects(
@@ -149,7 +147,7 @@ test(accessTokenServiceTests, "getRefreshToken not implemented", async () => {
   );
 });
 
-test(
+it(
   accessTokenServiceTests,
   "acceptedScope defaults to always passing",
   async () => {
@@ -164,11 +162,9 @@ test(
 
 const refreshTokenService = new RefreshTokenService();
 
-const refreshTokenServiceTests: TestSuite<void> = new TestSuite({
-  name: "RefreshTokenService",
-});
+const refreshTokenServiceTests = describe("RefreshTokenService");
 
-test(refreshTokenServiceTests, "generateAccessToken", async () => {
+it(refreshTokenServiceTests, "generateAccessToken", async () => {
   const result = refreshTokenService.generateAccessToken(
     client,
     user,
@@ -183,7 +179,7 @@ test(refreshTokenServiceTests, "generateAccessToken", async () => {
   );
 });
 
-test(refreshTokenServiceTests, "accessTokenExpiresAt", async () => {
+it(refreshTokenServiceTests, "accessTokenExpiresAt", async () => {
   const time = new FakeTime();
   try {
     const hour = 60 * 60 * 1000;
@@ -205,7 +201,7 @@ test(refreshTokenServiceTests, "accessTokenExpiresAt", async () => {
   }
 });
 
-test(
+it(
   refreshTokenServiceTests,
   "accessTokenExpiresAt with client.accessTokenLifetime",
   async () => {
@@ -237,7 +233,7 @@ test(
   },
 );
 
-test(refreshTokenServiceTests, "generateRefreshToken", async () => {
+it(refreshTokenServiceTests, "generateRefreshToken", async () => {
   const result = refreshTokenService
     .generateRefreshToken(client, user, scope);
   assertStrictEquals(Promise.resolve(result), result);
@@ -253,7 +249,7 @@ test(refreshTokenServiceTests, "generateRefreshToken", async () => {
   );
 });
 
-test(refreshTokenServiceTests, "refreshTokenExpiresAt", async () => {
+it(refreshTokenServiceTests, "refreshTokenExpiresAt", async () => {
   const time = new FakeTime();
   try {
     const twoWeeks = 14 * 24 * 60 * 60 * 1000;
@@ -275,7 +271,7 @@ test(refreshTokenServiceTests, "refreshTokenExpiresAt", async () => {
   }
 });
 
-test(
+it(
   refreshTokenServiceTests,
   "refreshTokenExpiresAt with client.refreshTokenLifetime",
   async () => {

--- a/services/user_test.ts
+++ b/services/user_test.ts
@@ -3,8 +3,8 @@ import {
   assertNotEquals,
   assertRejects,
   assertStrictEquals,
-  test,
-  TestSuite,
+  describe,
+  it,
 } from "../test_deps.ts";
 import { ServerError } from "../errors.ts";
 import { UserService } from "./test_services.ts";
@@ -12,11 +12,9 @@ import { generateSalt, hashPassword } from "./user.ts";
 
 const userService = new UserService();
 
-const userServiceTests: TestSuite<void> = new TestSuite({
-  name: "UserService",
-});
+const userServiceTests = describe("UserService");
 
-test(userServiceTests, "getAuthenticated not implemented", async () => {
+it(userServiceTests, "getAuthenticated not implemented", async () => {
   const result = userService.getAuthenticated(
     "Kyle",
     "hunter2",
@@ -30,7 +28,7 @@ test(userServiceTests, "getAuthenticated not implemented", async () => {
   );
 });
 
-test("generateSalt", () => {
+it("generateSalt", () => {
   const salts = [
     generateSalt(),
     generateSalt(),
@@ -40,7 +38,7 @@ test("generateSalt", () => {
   assertEquals(salts[1].length, 32);
 });
 
-test("hashPassword", async () => {
+it("hashPassword", async () => {
   const passwords = ["hunter1", "hunter2"];
   const salts = [
     "ba387b742a3e1917d084d067e3a65b63",

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -8,22 +8,18 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.120.0/testing/asserts.ts";
-export { delay } from "https://deno.land/std@0.120.0/async/delay.ts";
-export { v4 } from "https://deno.land/std@0.120.0/uuid/mod.ts";
+} from "https://deno.land/std@0.133.0/testing/asserts.ts";
+export { delay } from "https://deno.land/std@0.133.0/async/delay.ts";
+export { v4 } from "https://deno.land/std@0.133.0/uuid/mod.ts";
 
 export {
   assertSpyCall,
   assertSpyCallAsync,
   assertSpyCalls,
-  FakeTime,
   spy,
   stub,
-} from "https://deno.land/x/mock@0.12.2/mod.ts";
-export type {
-  Spy,
-  SpyCall,
-  Stub,
-} from "https://deno.land/x/mock@0.12.2/mod.ts";
+} from "https://deno.land/std@0.133.0/testing/mock.ts";
+export type { Spy, Stub } from "https://deno.land/std@0.133.0/testing/mock.ts";
+export { FakeTime } from "https://deno.land/x/mock@0.15.0/time.ts";
 
-export { test, TestSuite } from "https://deno.land/x/test_suite@0.9.5/mod.ts";
+export { describe, it } from "https://deno.land/x/test_suite@0.14.0/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -22,4 +22,4 @@ export {
 export type { Spy, Stub } from "https://deno.land/std@0.133.0/testing/mock.ts";
 export { FakeTime } from "https://deno.land/x/mock@0.15.0/time.ts";
 
-export { describe, it } from "https://deno.land/x/test_suite@0.14.0/mod.ts";
+export { describe, it } from "https://deno.land/x/test_suite@0.16.0/mod.ts";


### PR DESCRIPTION
I had some refresh logic on the authorization server when I shouldn't have. I've also improved the example to use accessToken and refreshToken cookies for first party client instead of using a session on all requests that has both the accessToken and refreshToken. The old way wasn't as secure. With this change, the refresh tokens are only sent over http when requests are made to a few specific endpoints.